### PR TITLE
Fix build on linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,9 +12,11 @@ else()
     link_libraries(pthread)
     link_libraries(GL)
     link_libraries(GLEW)
+	link_libraries(X11)
+	link_libraries(Xxf86vm)
 
     # GLFW3
-    link_libraries(glfw)
+    link_libraries(glfw3)
 
     # FFTW3
     link_libraries(fftw3)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,8 +12,8 @@ else()
     link_libraries(pthread)
     link_libraries(GL)
     link_libraries(GLEW)
-	link_libraries(X11)
-	link_libraries(Xxf86vm)
+    link_libraries(X11)
+    link_libraries(Xxf86vm)
 
     # GLFW3
     link_libraries(glfw3)


### PR DESCRIPTION
glfw for some reason requires X11 and Xxf86vm to be explicitly marked before it.