### PR TITLE
Build system fix and cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ build/
 *.dll
 *.exe
 *.zip
+.DS_Store

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,7 @@ target_link_libraries(sdrpp PRIVATE sdrpp_core)
 # Copy dynamic libs over
 if (MSVC)
     add_custom_target(do_always ALL xcopy /s \"$<TARGET_FILE_DIR:sdrpp_core>\\*.dll\" \"$<TARGET_FILE_DIR:sdrpp>\" /Y)
+    add_custom_target(do_always_volk ALL xcopy /s \"C:/Program Files/PothosSDR/bin\\volk.dll\" \"$<TARGET_FILE_DIR:sdrpp>\" /Y)
 endif (MSVC)
 
 if (${CMAKE_SYSTEM_NAME} MATCHES "Linux")

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -60,6 +60,8 @@ if (MSVC)
     find_package(portaudio CONFIG REQUIRED)
     target_link_libraries(sdrpp_core PUBLIC portaudio portaudio_static)
 
+    target_link_libraries(sdrpp_core PUBLIC volk)
+
 endif (MSVC)
 
 if (${CMAKE_SYSTEM_NAME} MATCHES "Linux")
@@ -76,41 +78,48 @@ if (${CMAKE_SYSTEM_NAME} MATCHES "Linux")
     target_link_libraries(sdrpp_core PUBLIC Xxf86vm)
     target_link_libraries(sdrpp_core PUBLIC dl)
     target_link_libraries(sdrpp_core PUBLIC stdc++fs)
+    target_link_libraries(sdrpp_core PUBLIC volk)
 endif ()
 
 
 if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+    find_package(PkgConfig)
     find_package(OpenGL REQUIRED)
 
-    # find_package(GLEW REQUIRED)
-    # find_package(fftw3 REQUIRED)
-    # find_package(glfw3 REQUIRED)
-    # find_package(volk REQUIRED)
+    pkg_check_modules(GLEW REQUIRED GLEW)
+    pkg_check_modules(FFTW3 REQUIRED fftw3f)
+    pkg_check_modules(VOLK REQUIRED volk)
+    pkg_check_modules(GLFW3 REQUIRED glfw3)
+    pkg_check_modules(PORTAUDIO REQUIRED portaudio-2.0)
 
-    target_include_directories(sdrpp_core PUBLIC /usr/local/opt/glew/include)
-    target_include_directories(sdrpp_core PUBLIC /usr/local/opt/glfw/include)
-    target_include_directories(sdrpp_core PUBLIC /usr/local/opt/fftw/include)
-    target_include_directories(sdrpp_core PUBLIC /usr/local/opt/portaudio/include)
-    target_include_directories(sdrpp_core PUBLIC /usr/local/opt/volk/include)
-    target_include_directories(sdrpp_core PUBLIC /usr/local/opt/volk/include/volk)
+    target_include_directories(sdrpp_core PUBLIC
+        ${GLEW_INCLUDE_DIRS}
+        ${FFTW3_INCLUDE_DIRS}
+        ${GLFW3_INCLUDE_DIRS}
+        ${VOLK_INCLUDE_DIRS} ${VOLK_INCLUDE_DIRS}/volk
+        ${PORTAUDIO_INCLUDE_DIRS}
+        )
 
-    target_link_directories(sdrpp_core PUBLIC /usr/local/opt/glew/lib)
-    target_link_directories(sdrpp_core PUBLIC /usr/local/opt/volk/lib)
-    target_link_directories(sdrpp_core PUBLIC /usr/local/opt/glfw/lib)
-    target_link_directories(sdrpp_core PUBLIC /usr/local/opt/fftw/lib)
-    target_link_directories(sdrpp_core PUBLIC /usr/local/opt/portaudio/lib)
+    target_link_directories(sdrpp_core PUBLIC
+        ${GLEW_LIBRARY_DIRS}
+        ${FFTW3_LIBRARY_DIRS}
+        ${GLFW3_LIBRARY_DIRS}
+        ${VOLK_LIBRARY_DIRS}
+        ${PORTAUDIO_LIBRARY_DIRS}
+        )
 
-    target_link_libraries(sdrpp_core PUBLIC ${OPENGL_LIBRARIES})
-    target_link_libraries(sdrpp_core PUBLIC volk)
-    target_link_libraries(sdrpp_core PUBLIC glew)
-    target_link_libraries(sdrpp_core PUBLIC glfw)
-    target_link_libraries(sdrpp_core PUBLIC fftw3)
-    target_link_libraries(sdrpp_core PUBLIC fftw3f)
-    target_link_libraries(sdrpp_core PUBLIC portaudio)
+    target_link_libraries(sdrpp_core PUBLIC
+        ${OPENGL_LIBRARIES}
+        ${GLEW_STATIC_LIBRARIES}
+        ${FFTW3_STATIC_LIBRARIES}
+        ${GLFW3_STATIC_LIBRARIES}
+        ${VOLK_STATIC_LIBRARIES}
+        ${PORTAUDIO_STATIC_LIBRARIES}
+        )
 
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -static")
+    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -static-libgcc -static-libstdc++")
 endif ()
-
-target_link_libraries(sdrpp_core PUBLIC volk)
 
 set(CORE_FILES ${RUNTIME_OUTPUT_DIRECTORY} PARENT_SCOPE)
 

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -11,16 +11,10 @@ endif (MSVC)
 add_definitions(-DSDRPP_IS_CORE)
 
 # Main code
-file(GLOB SRC "src/*.cpp")
-file(GLOB GUI "src/gui/*.cpp")
-file(GLOB MENUS "src/gui/menus/*.cpp")
-file(GLOB DIALOGS "src/gui/dialogs/*.cpp")
-file(GLOB SIGPATH "src/signal_path/*.cpp")
-file(GLOB IMGUI "src/imgui/*.cpp")
-file(GLOB DUKTAPE "src/duktape/*.c")
+file(GLOB_RECURSE SRC "src/*.cpp" "src/*.c")
 
 # Add code to dyn lib
-add_library(sdrpp_core SHARED ${SRC} ${GUI} ${MENUS} ${DIALOGS} ${SIGPATH} ${IMGUI} ${DUKTAPE})
+add_library(sdrpp_core SHARED ${SRC})
 set_target_properties(sdrpp_core PROPERTIES PREFIX "")
 
 # Include core headers
@@ -61,29 +55,11 @@ if (MSVC)
 
     target_link_libraries(sdrpp_core PUBLIC volk)
 
-endif (MSVC)
-
-if (${CMAKE_SYSTEM_NAME} MATCHES "Linux")
-    target_link_libraries(sdrpp_core PUBLIC pthread)
-    target_link_libraries(sdrpp_core PUBLIC GL)
-    target_link_libraries(sdrpp_core PUBLIC GLEW)
-    target_link_libraries(sdrpp_core PUBLIC glfw)
-    target_link_libraries(sdrpp_core PUBLIC fftw3)
-    target_link_libraries(sdrpp_core PUBLIC fftw3f)
-    target_link_libraries(sdrpp_core PUBLIC portaudio)
-    target_link_libraries(sdrpp_core PUBLIC X11)
-    target_link_libraries(sdrpp_core PUBLIC Xxf86vm)
-    target_link_libraries(sdrpp_core PUBLIC dl)
-    target_link_libraries(sdrpp_core PUBLIC stdc++fs)
-    target_link_libraries(sdrpp_core PUBLIC volk)
-endif ()
-
-
-if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+else()
     find_package(PkgConfig)
     find_package(OpenGL REQUIRED)
 
-    pkg_check_modules(GLEW REQUIRED GLEW)
+    pkg_check_modules(GLEW REQUIRED glew)
     pkg_check_modules(FFTW3 REQUIRED fftw3f)
     pkg_check_modules(VOLK REQUIRED volk)
     pkg_check_modules(GLFW3 REQUIRED glfw3)
@@ -114,8 +90,15 @@ if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
         ${PORTAUDIO_STATIC_LIBRARIES}
         )
 
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -static")
-    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -static-libgcc -static-libstdc++")
+    if (${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+        target_link_libraries(sdrpp_core PUBLIC stdc++fs)
+    endif ()
+
+    if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -static")
+        set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -static-libgcc -static-libstdc++")
+    endif ()
+
 endif ()
 
 set(CORE_FILES ${RUNTIME_OUTPUT_DIRECTORY} PARENT_SCOPE)

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -6,7 +6,7 @@ if (MSVC)
     set(CMAKE_CXX_FLAGS "-O2 /std:c++17")
     set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
 else()
-    set(CMAKE_CXX_FLAGS "-O3 -std=c++17 -fpermissive")
+    set(CMAKE_CXX_FLAGS "-g -O3 -std=c++17 -fpermissive")
 endif (MSVC)
 add_definitions(-DSDRPP_IS_CORE)
 
@@ -75,6 +75,7 @@ if (${CMAKE_SYSTEM_NAME} MATCHES "Linux")
     target_link_libraries(sdrpp_core PUBLIC X11)
     target_link_libraries(sdrpp_core PUBLIC Xxf86vm)
     target_link_libraries(sdrpp_core PUBLIC dl)
+    target_link_libraries(sdrpp_core PUBLIC stdc++fs)
 endif ()
 
 

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -44,8 +44,6 @@ if (MSVC)
     target_link_libraries(sdrpp_core PUBLIC glfw)
 
     # FFTW3
-    find_package(FFTW3 CONFIG REQUIRED)
-    target_link_libraries(sdrpp_core PUBLIC FFTW3::fftw3)
     find_package(FFTW3f CONFIG REQUIRED)
     target_link_libraries(sdrpp_core PUBLIC FFTW3::fftw3f)
 

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -36,7 +36,6 @@ if (MSVC)
     target_include_directories(sdrpp_core PUBLIC "C:/Program Files/PothosSDR/include/")
 
     # Volk
-    target_include_directories(sdrpp_core PUBLIC "C:/Program Files/PothosSDR/include/volk/")
     target_link_libraries(sdrpp_core PUBLIC volk)
     
     # SoapySDR
@@ -65,8 +64,6 @@ if (MSVC)
 endif (MSVC)
 
 if (${CMAKE_SYSTEM_NAME} MATCHES "Linux")
-    target_include_directories(sdrpp_core PUBLIC "/usr/include/volk")
-
     target_link_libraries(sdrpp_core PUBLIC pthread)
     target_link_libraries(sdrpp_core PUBLIC GL)
     target_link_libraries(sdrpp_core PUBLIC GLEW)
@@ -96,7 +93,7 @@ if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
         ${GLEW_INCLUDE_DIRS}
         ${FFTW3_INCLUDE_DIRS}
         ${GLFW3_INCLUDE_DIRS}
-        ${VOLK_INCLUDE_DIRS} ${VOLK_INCLUDE_DIRS}/volk
+        ${VOLK_INCLUDE_DIRS}
         ${PORTAUDIO_INCLUDE_DIRS}
         )
 

--- a/core/src/core.cpp
+++ b/core/src/core.cpp
@@ -135,11 +135,11 @@ int sdrpp_main() {
     glfwMakeContextCurrent(window);
     glfwSwapInterval(1); // Enable vsync
 
+#if (GLFW_VERSION_MAJOR == 3) && (GLFW_VERSION_MINOR >= 3)
     if (maximized) {
         glfwMaximizeWindow(window);
     }
 
-#if (GLFW_VERSION_MINOR == 3) && (GLFW_VERSION_MINOR >= 2)
     glfwSetWindowMaximizeCallback(window, maximized_callback);
 #endif
 

--- a/core/src/core.cpp
+++ b/core/src/core.cpp
@@ -139,7 +139,9 @@ int sdrpp_main() {
         glfwMaximizeWindow(window);
     }
 
+#if (GLFW_VERSION_MINOR == 3) && (GLFW_VERSION_MINOR >= 2)
     glfwSetWindowMaximizeCallback(window, maximized_callback);
+#endif
 
     // Load app icon
     GLFWimage icons[10];

--- a/core/src/dsp/block.h
+++ b/core/src/dsp/block.h
@@ -1,7 +1,7 @@
 #pragma once
 #include <vector>
 #include <dsp/stream.h>
-#include <volk.h>
+#include <volk/volk.h>
 
 namespace dsp {
     template <class D, class I, class O, int IC, int OC>

--- a/core/src/dsp/math.h
+++ b/core/src/dsp/math.h
@@ -2,7 +2,7 @@
 #include <thread>
 #include <dsp/stream.h>
 #include <dsp/types.h>
-#include <volk.h>
+#include <volk/volk.h>
 
 #ifndef M_PI
 #define M_PI    3.1415926535f

--- a/core/src/dsp/source.h
+++ b/core/src/dsp/source.h
@@ -2,7 +2,6 @@
 #include <thread>
 #include <dsp/stream.h>
 #include <dsp/types.h>
-#include <volk.h>
 #include <spdlog/spdlog.h>
 
 namespace dsp {

--- a/soapy/CMakeLists.txt
+++ b/soapy/CMakeLists.txt
@@ -19,9 +19,15 @@ add_library(soapy SHARED ${SRC})
 target_link_libraries(soapy PRIVATE sdrpp_core)
 set_target_properties(soapy PROPERTIES PREFIX "")
 
-target_link_libraries(soapy PUBLIC SoapySDR)
-
 if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
-    target_include_directories(soapy PUBLIC /usr/local/opt/soapysdr/include)
-    target_link_directories(soapy PUBLIC /usr/local/opt/soapysdr/lib)
+    find_package(PkgConfig)
+    find_package(OpenGL REQUIRED)
+
+    pkg_check_modules(SOAPY REQUIRED soapysdr)
+
+    target_include_directories(soapy PUBLIC ${SOAPY_INCLUDE_DIRS})
+    target_link_directories(soapy PUBLIC ${SOAPY_LIBRARY_DIRS})
+    target_link_libraries(soapy PUBLIC ${SOAPY_LIBRARIES})
+else ()
+    target_link_libraries(soapy PUBLIC SoapySDR)
 endif ()

--- a/soapy/CMakeLists.txt
+++ b/soapy/CMakeLists.txt
@@ -3,12 +3,6 @@ project(soapy)
 
 if (MSVC)
     set(CMAKE_CXX_FLAGS "-O2 /std:c++17")
-
-    # Lib path
-    target_link_directories(sdrpp_core PUBLIC "C:/Program Files/PothosSDR/lib/")
-
-    # Misc headers
-    target_include_directories(sdrpp_core PUBLIC "C:/Program Files/PothosSDR/include/")
 else()
     set(CMAKE_CXX_FLAGS "-O3 -std=c++17 -fpermissive")
 endif (MSVC)
@@ -19,15 +13,18 @@ add_library(soapy SHARED ${SRC})
 target_link_libraries(soapy PRIVATE sdrpp_core)
 set_target_properties(soapy PROPERTIES PREFIX "")
 
-if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
-    find_package(PkgConfig)
-    find_package(OpenGL REQUIRED)
+if (MSVC)
+    # Lib path
+    target_link_directories(sdrpp_core PUBLIC "C:/Program Files/PothosSDR/lib/")
 
-    pkg_check_modules(SOAPY REQUIRED soapysdr)
+    # Misc headers
+    target_include_directories(sdrpp_core PUBLIC "C:/Program Files/PothosSDR/include/")
+else (MSVC)
+    find_package(PkgConfig)
+
+    pkg_check_modules(SOAPY REQUIRED SoapySDR)
 
     target_include_directories(soapy PUBLIC ${SOAPY_INCLUDE_DIRS})
     target_link_directories(soapy PUBLIC ${SOAPY_LIBRARY_DIRS})
     target_link_libraries(soapy PUBLIC ${SOAPY_LIBRARIES})
-else ()
-    target_link_libraries(soapy PUBLIC SoapySDR)
-endif ()
+endif (MSVC)


### PR DESCRIPTION
Couple of fixes to the build system:
1. Fix build on Debian 10
2. Use pkg-config to find out all the path of includes/libs on Linux and OSX, and remove all hardcoded path.