### PR TITLE
Fix file source rewind and read after it is finished

### DIFF
--- a/falcon9_decoder/CMakeLists.txt
+++ b/falcon9_decoder/CMakeLists.txt
@@ -12,6 +12,8 @@ file(GLOB_RECURSE SRC "src/*.cpp" "src/*.c")
 include_directories("src/")
 include_directories("src/libcorrect/")
 
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -march=native")
+
 add_library(falcon9_decoder SHARED ${SRC})
 target_link_libraries(falcon9_decoder PRIVATE sdrpp_core)
 set_target_properties(falcon9_decoder PROPERTIES PREFIX "")

--- a/file_source/src/wavreader.h
+++ b/file_source/src/wavreader.h
@@ -43,6 +43,7 @@ public:
         file.read(_data, size);
         int read = file.gcount();
         if (read < size) {
+            file.clear();
             file.seekg(sizeof(WavHeader_t));
             file.read(&_data[read], size - read);
         }


### PR DESCRIPTION
Calling clear() clears the eof state flag which prevents further reading from the stream.