### PR TITLE
Fix build with Windows SDK 8.1 or more, fix typos in airspy_source

### DIFF
--- a/airspy_source/src/main.cpp
+++ b/airspy_source/src/main.cpp
@@ -113,7 +113,7 @@ public:
             if (err != 0) {
                 char buf[1024];
                 sprintf(buf, "%016" PRIX64, serial);
-                spdlog::error("Could not open Airspy HF+ {0}", buf);
+                spdlog::error("Could not open Airspy {0}", buf);
                 selectedSerial = 0;
                 return;
             }
@@ -121,7 +121,7 @@ public:
         catch (std::exception e) {
             char buf[1024];
             sprintf(buf, "%016" PRIX64, serial);
-            spdlog::error("Could not open Airspy HF+ {0}", buf);
+            spdlog::error("Could not open Airspy {0}", buf);
         }
         selectedSerial = serial;
 
@@ -240,7 +240,7 @@ private:
             return;
         }
         if (_this->selectedSerial == 0) {
-            spdlog::error("Tried to start AirspyHF+ source with null serial");
+            spdlog::error("Tried to start Airspy source with null serial");
             return;
         }
 

--- a/core/src/gui/widgets/folder_select.h
+++ b/core/src/gui/widgets/folder_select.h
@@ -6,7 +6,7 @@
 
 #ifdef _WIN32
 #include <Windows.h>
-#include <ShlObj_core.h>
+#include <ShlObj.h>
 #include <thread>
 #endif
 


### PR DESCRIPTION
Replace Windows SDK 10 #include <ShlObj_core.h> by #include <ShlObj.h> supported by Windows SDK 8.1 or more