### PR TITLE
Added band allocation plan for the USA

### DIFF
--- a/root/res/bandplans/usa.json
+++ b/root/res/bandplans/usa.json
@@ -1,0 +1,315 @@
+{
+    "name": "USA",
+    "country_name": "United States of America",
+    "country_code": "US",
+    "author_name": "Joshua Kimsey",
+    "author_url": "http://jkimsey.tech",
+    "bands": [
+        {
+            "name": "Long Wave",
+            "type": "broadcast",
+            "start": 148500,
+            "end": 519000
+        },
+        {
+            "name": "Medium Wave (AM Broadcast)",
+            "type": "broadcast",
+            "start": 525000,
+            "end": 1705000
+        },
+        {
+            "name": "160m Ham Band",
+            "type": "amateur",
+            "start": 1800000,
+            "end": 2000000
+        },
+        {
+            "name": "Shortwave Broadcast",
+            "type": "broadcast",
+            "start": 2300000,
+            "end": 2468000
+        },
+        {
+            "name": "Shortwave Broadcast",
+            "type": "broadcast",
+            "start": 3200000,
+            "end": 3400000
+        },
+        {
+            "name": "80m Ham Band",
+            "type": "amateur",
+            "start": 3500000,
+            "end": 3950000
+        },
+        {
+            "name": "Shortwave Broadcast",
+            "type": "broadcast",
+            "start": 3950000,
+            "end": 4000000
+        },
+        {
+            "name": "Shortwave Broadcast",
+            "type": "broadcast",
+            "start": 4750000,
+            "end": 4995000
+        },
+        {
+            "name": "Shortwave Broadcast",
+            "type": "broadcast",
+            "start": 5005000,
+            "end": 5060000
+        },
+        {
+            "name": "60m Ham Band",
+            "type": "amateur",
+            "start": 5351500,
+            "end": 5366500
+        },
+        {
+            "name": "Shortwave Broadcast",
+            "type": "broadcast",
+            "start": 5900000,
+            "end": 6200000
+        },
+        {
+            "name": "40m Ham Band",
+            "type": "amateur",
+            "start": 7000000,
+            "end": 7200000
+        },
+        {
+            "name": "Shortwave Broadcast",
+            "type": "broadcast",
+            "start": 7200000,
+            "end": 7450000
+        },
+        {
+            "name": "Shortwave Broadcast",
+            "type": "broadcast",
+            "start": 9400000,
+            "end": 9900000
+        },
+        {
+            "name": "30m Ham Band",
+            "type": "amateur",
+            "start": 10100000,
+            "end": 10150000
+        },
+        {
+            "name": "Shortwave Broadcast",
+            "type": "broadcast",
+            "start": 11600000,
+            "end": 12100000
+        },
+        {
+            "name": "Shortwave Broadcast",
+            "type": "broadcast",
+            "start": 13570000,
+            "end": 13870000
+        },
+        {
+            "name": "20m Ham Band",
+            "type": "amateur",
+            "start": 14000000,
+            "end": 14350000
+        },
+        {
+            "name": "Shortwave Broadcast",
+            "type": "broadcast",
+            "start": 15100000,
+            "end": 15800000
+        },
+        {
+            "name": "Shortwave Broadcast",
+            "type": "broadcast",
+            "start": 17480000,
+            "end": 17900000
+        },
+        {
+            "name": "17m Ham Band",
+            "type": "amateur",
+            "start": 18068000,
+            "end": 18168000
+        },
+        {
+            "name": "Shortwave Broadcast",
+            "type": "broadcast",
+            "start": 18900000,
+            "end": 19020000
+        },
+        {
+            "name": "15m Ham Band",
+            "type": "amateur",
+            "start": 21000000,
+            "end": 21450000
+        },
+        {
+            "name": "Shortwave Broadcast",
+            "type": "broadcast",
+            "start": 21450000,
+            "end": 21850000
+        },
+        {
+            "name": "12m Ham Band",
+            "type": "amateur",
+            "start": 24890000,
+            "end": 24990000
+        },
+        {
+            "name": "Shortwave Broadcast",
+            "type": "broadcast",
+            "start": 25670000,
+            "end": 26100000
+        },
+        {
+            "name": "CB",
+            "type": "amateur",
+            "start": 26960000,
+            "end": 27410000
+        },
+        {
+            "name": "10m Ham Band",
+            "type": "amateur",
+            "start": 28000000,
+            "end": 29750000
+        },
+        {
+            "name": "6m Ham Band",
+            "type": "amateur",
+            "start": 50000000,
+            "end": 54000000
+        },
+        {
+            "name": "TV Channels 2-4",
+            "type": "broadcast",
+            "start": 54000000,
+            "end": 72000000
+        },
+        {
+            "name": "TV Channels 5-6",
+            "type": "broadcast",
+            "start": 76000000,
+            "end": 88000000
+        },
+        {
+            "name": "FM Broadcast",
+            "type": "broadcast",
+            "start": 87500000,
+            "end": 108000000
+        },
+        {
+            "name": "Air Band VOR/ILS",
+            "type": "aviation",
+            "start": 108000000,
+            "end": 118000000
+        },
+        {
+            "name": "Air Band Voice",
+            "type": "aviation",
+            "start": 118000000,
+            "end": 137000000
+        },
+        {
+            "name": "Polar Orbiting Satellites",
+            "type": "satellite",
+            "start": 137000000,
+            "end": 138000000
+        },
+        {
+            "name": "2m Ham Band",
+            "type": "amateur",
+            "start": 144000000,
+            "end": 148000000
+        },
+        {
+            "name": "Marine",
+            "type": "marine",
+            "start": 156000000,
+            "end": 162025000
+        },
+        {
+            "name": "NOAA Weather Radio",
+            "type": "broadcast",
+            "start": 162362500,
+            "end": 162587500
+        },
+        {
+            "name": "TV Channels 7-13",
+            "type": "broadcast",
+            "start": 174000000,
+            "end": 216000000
+        },
+        {
+            "name": "1.25m Ham Band",
+            "type": "amateur",
+            "start": 222000000,
+            "end": 225000000
+        },
+        {
+            "name": "Military Air",
+            "type": "military",
+            "start": 225000000,
+            "end": 380000000
+        },
+        {
+            "name": "Military Sat",
+            "type": "military",
+            "start": 240000000,
+            "end": 270000000
+        },
+        {
+            "name": "70cm Ham Band",
+            "type": "amateur",
+            "start": 420000000,
+            "end": 450000000
+        },
+        {
+            "name": "PMR446",
+            "type": "amateur",
+            "start": 446000000,
+            "end": 446200000
+        },
+        {
+            "name": "TV Channels 14-20",
+            "type": "broadcast",
+            "start": 470000000,
+            "end": 512000000
+        },
+        {
+            "name": "TV Channels 21-36",
+            "type": "broadcast",
+            "start": 512000000,
+            "end": 608000000
+        },
+        {
+            "name": "TV Broadcasting",
+            "type": "broadcast",
+            "start": 614000000,
+            "end": 698000000
+        },
+        {
+            "name": "33cm Ham Band",
+            "type": "amateur",
+            "start": 902000000,
+            "end": 928000000
+        },
+        {
+            "name": "23cm Ham Band",
+            "type": "amateur",
+            "start": 1240000000,
+            "end": 1300000000
+        },
+        {
+            "name": "13cm Ham Band",
+            "type": "amateur",
+            "start": 2300000000,
+            "end": 2310000000
+        },
+        {
+            "name": "13cm Ham Band",
+            "type": "amateur",
+            "start": 2390000000,
+            "end": 2450000000
+        }
+    ]
+}


### PR DESCRIPTION
* Added band allocation markers for NOAA Weather Radio, Polar Orbiting Satellites, and TV Channel Broadcasting frequencies. Will add more as time moves along.

* Changed some frequencies to better fit with FCC declared frequency ranges.

* Fixed issue with bands array not being organised. Will now be organised by start frequency.

(All relevant information was pulled from the FCC to ensure accuracy)