### PR TITLE
Standardized sorting of bands array for band allocation plans

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -49,6 +49,68 @@ For example, lets take the module named `cool_source`:
 
 If the module meets the code quality requirements, it may be added to the official repository. A module that doesn't require any external dependencies that the core doesn't already use may be enabled for build by default. Otherwise, they must be disabled for build by default with a `OPT_BUILD_MODULE_NAME` variable set to `OFF`.
 
+# JSON Formatting
+
+The ability to add new radio band allocation identifiers and color maps relies on JSON files. Proper formatting of these JSOn files is important for reference and readability. The folowing guides will show you how to properly format the JSON files for their respective uses.
+
+## Band Frequency Allocation 
+
+Please follow this guide to properly format the JSON files for custom radio band allocation identifiers.
+
+```json
+{
+    "name": "Single Word: Name of the band plan ",
+    "country_name": "Name of country, if applicable (Use 'Worldwide' otherwise)",
+    "country_code": "Two letter country code, if applicable (Use '--' otherwise",
+    "author_name": "Name of the original/main creator of the JSON file",
+    "author_url": "URL the author wishes to be associated with the file (personal website, GitHub, Twitter, etc)",
+    "bands": [ 
+        // Bands in this array must be sorted by their starting frequency
+        {
+            "name": "Name of the band",
+            "type": "Type of band (Amatuer, Broadcast, Marine, Military, or Satellite)",
+            "start": 148500, //In Hz, must be an integer
+            "end": 283500 //In Hz, must be an integer
+        },
+        {
+            "name": "Name of the band",
+            "type": "Type of band (Amatuer, Broadcast, Marine, Military, or Satellite)",
+            "start": 526500, //In Hz, must be an integer
+            "end": 1606500 //In Hz, must be an integer
+        }    
+    ]
+}
+```
+
+## Color Maps
+
+Please follow this guide to properly format the JSON files for custom color maps.
+
+```json
+{
+    "name": "Name of the color map in a single word",
+    "author": "Name of the original/main creator of the color map",
+    "map": [
+        // These are the color codes, in hexidecimal format, for the custom color scales for the waterfall. They must be entered as strings, not integers, with the hastag/pound-symbol proceeding the 6 digit number. 
+        "#000020",
+        "#000030",
+        "#000050",
+        "#000091",
+        "#1E90FF",
+        "#FFFFFF",
+        "#FFFF00",
+        "#FE6D16",
+        "#FE6D16",
+        "#FF0000",
+        "#FF0000",
+        "#C60000",
+        "#9F0000",
+        "#750000",
+        "#4A0000"
+    ]
+}
+```
+
 # Best Practices
 
 * All additions and/or bug fixes to the core must not add additional dependencies.

--- a/root/res/bandplans/general.json
+++ b/root/res/bandplans/general.json
@@ -18,6 +18,12 @@
             "end": 1606500
         },
         {
+            "name": "160m Ham Band",
+            "type": "amateur",
+            "start": 1800000,
+            "end": 2000000
+        },
+        {
             "name": "Shortwave Broadcast",
             "type": "broadcast",
             "start": 2300000,
@@ -28,6 +34,12 @@
             "type": "broadcast",
             "start": 3200000,
             "end": 3400000
+        },
+        {
+            "name": "80m Ham Band",
+            "type": "amateur",
+            "start": 3500000,
+            "end": 3950000
         },
         {
             "name": "Shortwave Broadcast",
@@ -48,10 +60,22 @@
             "end": 5060000
         },
         {
+            "name": "60m Ham Band",
+            "type": "amateur",
+            "start": 5351500,
+            "end": 5366500
+        },
+        {
             "name": "Shortwave Broadcast",
             "type": "broadcast",
             "start": 5900000,
             "end": 6200000
+        },
+        {
+            "name": "40m Ham Band",
+            "type": "amateur",
+            "start": 7000000,
+            "end": 7200000
         },
         {
             "name": "Shortwave Broadcast",
@@ -66,6 +90,12 @@
             "end": 9900000
         },
         {
+            "name": "30m Ham Band",
+            "type": "amateur",
+            "start": 10100000,
+            "end": 10150000
+        },
+        {
             "name": "Shortwave Broadcast",
             "type": "broadcast",
             "start": 11600000,
@@ -76,6 +106,12 @@
             "type": "broadcast",
             "start": 13570000,
             "end": 13870000
+        },
+        {
+            "name": "20m Ham Band",
+            "type": "amateur",
+            "start": 14000000,
+            "end": 14350000
         },
         {
             "name": "Shortwave Broadcast",
@@ -90,10 +126,22 @@
             "end": 17900000
         },
         {
+            "name": "17m Ham Band",
+            "type": "amateur",
+            "start": 18068000,
+            "end": 18168000
+        },
+        {
             "name": "Shortwave Broadcast",
             "type": "broadcast",
             "start": 18900000,
             "end": 19020000
+        },
+        {
+            "name": "15m Ham Band",
+            "type": "amateur",
+            "start": 21000000,
+            "end": 21450000
         },
         {
             "name": "Shortwave Broadcast",
@@ -102,10 +150,34 @@
             "end": 21850000
         },
         {
+            "name": "12m Ham Band",
+            "type": "amateur",
+            "start": 24890000,
+            "end": 24990000
+        },
+        {
             "name": "Shortwave Broadcast",
             "type": "broadcast",
             "start": 25670000,
             "end": 26100000
+        },
+        {
+            "name": "CB",
+            "type": "amateur",
+            "start": 26960000,
+            "end": 27410000
+        },
+        {
+            "name": "10m Ham Band",
+            "type": "amateur",
+            "start": 28000000,
+            "end": 29750000
+        },
+        {
+            "name": "6m Ham Band",
+            "type": "amateur",
+            "start": 50000000,
+            "end": 54000000
         },
         {
             "name": "FM Broadcast",
@@ -126,76 +198,10 @@
             "end": 137000000
         },
         {
-            "name": "160m Ham Band",
-            "type": "amateur",
-            "start": 1800000,
-            "end": 2000000
-        },
-        {
-            "name": "80m Ham Band",
-            "type": "amateur",
-            "start": 3500000,
-            "end": 3950000
-        },
-        {
-            "name": "60m Ham Band",
-            "type": "amateur",
-            "start": 5351500,
-            "end": 5366500
-        },
-        {
-            "name": "40m Ham Band",
-            "type": "amateur",
-            "start": 7000000,
-            "end": 7200000
-        },
-        {
-            "name": "30m Ham Band",
-            "type": "amateur",
-            "start": 10100000,
-            "end": 10150000
-        },
-        {
-            "name": "20m Ham Band",
-            "type": "amateur",
-            "start": 14000000,
-            "end": 14350000
-        },
-        {
-            "name": "17m Ham Band",
-            "type": "amateur",
-            "start": 18068000,
-            "end": 18168000
-        },
-        {
-            "name": "15m Ham Band",
-            "type": "amateur",
-            "start": 21000000,
-            "end": 21450000
-        },
-        {
-            "name": "12m Ham Band",
-            "type": "amateur",
-            "start": 24890000,
-            "end": 24990000
-        },
-        {
-            "name": "CB",
-            "type": "amateur",
-            "start": 26960000,
-            "end": 27410000
-        },
-        {
-            "name": "10m Ham Band",
-            "type": "amateur",
-            "start": 28000000,
-            "end": 29750000
-        },
-        {
-            "name": "6m Ham Band",
-            "type": "amateur",
-            "start": 50000000,
-            "end": 54000000
+            "name": "Polar Orbiting Satellites",
+            "type": "satellite",
+            "start": 137000000,
+            "end": 138000000
         },
         {
             "name": "2m Ham Band",

--- a/root/res/bandplans/germany-mobile-lte-bands.json
+++ b/root/res/bandplans/germany-mobile-lte-bands.json
@@ -6,16 +6,22 @@
     "author_url": "none",
     "bands": [
         {
-            "name": "LTE band 1 (IMT) FDD uplink",
+            "name": "LTE band 28 (APT) FDD uplink",
             "type": "LTE.FDD.uplink",
-            "start": 1920000000,
-            "end": 1980000000
+            "start": 703000000,
+            "end": 748000000
         },
         {
-            "name": "LTE band 1 (IMT) FDD downlink",
-            "type": "LTE.FDD.downlink",
-            "start": 2110000000,
-            "end": 2170000000
+            "name": "LTE band 20 (Digital Dividend) FDD uplink",
+            "type": "LTE.FDD.uplink",
+            "start": 832000000,
+            "end": 862000000
+        },
+        {
+            "name": "LTE band 8 (Extended GSM) FDD uplink",
+            "type": "LTE.FDD.uplink",
+            "start": 880000000,
+            "end": 915000000
         },
         {
             "name": "LTE band 3 (DCS) FDD uplink",
@@ -30,6 +36,18 @@
             "end": 1880000000
         },
         {
+            "name": "LTE band 1 (IMT) FDD uplink",
+            "type": "LTE.FDD.uplink",
+            "start": 1920000000,
+            "end": 1980000000
+        },
+        {
+            "name": "LTE band 1 (IMT) FDD downlink",
+            "type": "LTE.FDD.downlink",
+            "start": 2110000000,
+            "end": 2170000000
+        },
+        {
             "name": "LTE band 7 (IMT-E) FDD uplink",
             "type": "LTE.FDD.uplink",
             "start": 2500000000,
@@ -42,22 +60,10 @@
             "end": 2690000000
         },
         {
-            "name": "LTE band 8 (Extended GSM) FDD uplink",
-            "type": "LTE.FDD.uplink",
-            "start": 880000000,
-            "end": 915000000
-        },
-        {
-            "name": "LTE band 8 (Extended GSM) FDD downlink",
+            "name": "LTE band 28 (APT) FDD downlink",
             "type": "LTE.FDD.downlink",
-            "start": 9250000000,
-            "end": 9600000000
-        },
-        {
-            "name": "LTE band 20 (Digital Dividend) FDD uplink",
-            "type": "LTE.FDD.uplink",
-            "start": 832000000,
-            "end": 862000000
+            "start": 7580000000,
+            "end": 8030000000
         },
         {
             "name": "LTE band 20 (Digital Dividend) FDD downlink",
@@ -66,16 +72,10 @@
             "end": 8210000000
         },
         {
-            "name": "LTE band 28 (APT) FDD uplink",
-            "type": "LTE.FDD.uplink",
-            "start": 703000000,
-            "end": 748000000
-        },
-        {
-            "name": "LTE band 28 (APT) FDD downlink",
+            "name": "LTE band 8 (Extended GSM) FDD downlink",
             "type": "LTE.FDD.downlink",
-            "start": 7580000000,
-            "end": 8030000000
+            "start": 9250000000,
+            "end": 9600000000
         },
         {
             "name": "LTE band 32 (L-Band (EU)) SDL downlink",

--- a/root/res/bandplans/germany-mobile-networks.json
+++ b/root/res/bandplans/germany-mobile-networks.json
@@ -137,7 +137,7 @@
             "start": 1452000000,
             "end": 1472000000
         },
-    	{
+        {
             "name": "1472 Vodafone SDL downlink",
             "type": "mobile.mno.vodafone",
             "start": 1472000000,
@@ -149,7 +149,7 @@
             "start": 1710000000,
             "end": 1740000000
         },
-	{
+        {
             "name": "1740 Telefonica FDD uplink",
             "type": "mobile.mno.telefonica",
             "start": 1740000000,
@@ -167,7 +167,7 @@
             "start": 1805000000,
             "end": 1835000000
         },
-	{
+        {
             "name": "1835 Telefonica FDD downlink",
             "type": "mobile.mno.telefonica",
             "start": 1835000000,
@@ -185,7 +185,7 @@
             "start": 1880000000,
             "end": 1900000000
         },
-	{
+        {
             "name": "1900.1 Telefonica",
             "type": "mobile.mno.telefonica",
             "start": 1900100000,
@@ -197,7 +197,7 @@
             "start": 1920000000,
             "end": 1940000000
         },
-	{
+        {
             "name": "1940 Telefonica FDD uplink",
             "type": "mobile.mno.telefonica",
             "start": 1940000000,
@@ -209,7 +209,7 @@
             "start": 1960000000,
             "end": 1980000000
         },
-	{
+        {
             "name": "2010.5 Telefonica",
             "type": "mobile.mno.telefonica",
             "start": 2010500000,
@@ -221,7 +221,7 @@
             "start": 2110000000,
             "end": 2130000000
         },
-	{
+        {
             "name": "2130 Telefonica FDD downlink",
             "type": "mobile.mno.telefonica",
             "start": 2130000000,
@@ -245,13 +245,13 @@
             "start": 2520000000,
             "end": 2540000000
         },
-	{
+        {
             "name": "2540 Telefonica FDD uplink",
             "type": "mobile.mno.telefonica",
             "start": 2540000000,
             "end": 2570000000
         },
-	{
+        {
             "name": "2570 Telefonica TDD",
             "type": "mobile.mno.telefonica",
             "start": 2570000000,
@@ -269,7 +269,7 @@
             "start": 2605000000,
             "end": 2610000000
         },
-	{
+        {
             "name": "2610 Telefonica TDD",
             "type": "mobile.mno.telefonica",
             "start": 2610000000,
@@ -287,7 +287,7 @@
             "start": 2640000000,
             "end": 2660000000
         },
-	{
+        {
             "name": "2660 Telefonica FDD downlink",
             "type": "mobile.mno.telefonica",
             "start": 2660000000,

--- a/root/res/bandplans/russia.json
+++ b/root/res/bandplans/russia.json
@@ -348,16 +348,16 @@
             "end": 24990000
         },
         {
-            "name": "SW 11m",
-            "type": "broadcast",
-            "start": 25650000,
-            "end": 26100000
-        },
-        {
             "name": "CB",
             "type": "amateur",
             "start": 25165000,
             "end": 30105000
+        },
+        {
+            "name": "SW 11m",
+            "type": "broadcast",
+            "start": 25650000,
+            "end": 26100000
         },
         {
             "name": "10m CW",


### PR DESCRIPTION
* Standardized organisation of the bands array in the band allocation JSON files. They are now organised by the starting frequency.

* Added 'Polar Orbiting Satellites' to the general JSON file, as that affects all general users.