### PR TITLE
Added more de-emphasis options

### DIFF
--- a/radio/src/wfm_demod.h
+++ b/radio/src/wfm_demod.h
@@ -179,7 +179,7 @@ public:
     }
 
     void setDeempIndex(int id) {
-        if (id >= 2 || id < 0) {
+        if (id >= 5 || id < 0) {
             deemp.bypass = true;
             return;
         }
@@ -202,8 +202,8 @@ private:
     const float bwMax = 250000;
     const float bwMin = 50000;
     const float bbSampRate = 250000;
-    const char* deempModes = "50µs\00075µs\000none\000";
-    const float deempVals[2] = { 50e-6, 75e-6 };
+    const char* deempModes = "10µs\00025µs\00032µs\00050µs\00075µs\000none\000";
+    const float deempVals[5] = { 10e-6, 25e-6, 32e-6, 50e-6, 75e-6 };
 
     std::string uiPrefix;
     float snapInterval = 100000;

--- a/radio/src/wfm_demod.h
+++ b/radio/src/wfm_demod.h
@@ -179,7 +179,7 @@ public:
     }
 
     void setDeempIndex(int id) {
-        if (id >= 5 || id < 0) {
+        if (id == 0) {
             deemp.bypass = true;
             return;
         }
@@ -202,8 +202,8 @@ private:
     const float bwMax = 250000;
     const float bwMin = 50000;
     const float bbSampRate = 250000;
-    const char* deempModes = "10µs\00025µs\00032µs\00050µs\00075µs\000none\000";
-    const float deempVals[5] = { 10e-6, 25e-6, 32e-6, 50e-6, 75e-6 };
+    const char* deempModes = "none\00010µs\00025µs\00032µs\00050µs\00075µs\000";
+    const float deempVals[6] = { 0, 10e-6, 25e-6, 32e-6, 50e-6, 75e-6 };
 
     std::string uiPrefix;
     float snapInterval = 100000;


### PR DESCRIPTION
* Added options for 10µs, 25µs, and 32µs de-emphasis options, to bring it in-line with what CubicSDR offers. This gives users more options for how much or little de-emphasis they desire. Done in reference to issue #107.

* Moved the 'none' option to the top of the drop-down menu from the bottom, as this makes more sense to most normal users. (At least in the USA, maybe it's different in other parts of the world?)