### PR TITLE
Fix Canada bandplan

### DIFF
--- a/root/res/bandplans/canada.json
+++ b/root/res/bandplans/canada.json
@@ -163,7 +163,7 @@
     },
     {
       "name": "Weatheradio",
-      "type": "amateur",
+      "type": "broadcast",
       "start": 162400000,
       "end": 162700000
     },


### PR DESCRIPTION
Weatheradio/Environment Canada was mistyped as an amateur band, this has been fixed.