### PR TITLE
Simplified ConfigManager

### DIFF
--- a/core/src/config.cpp
+++ b/core/src/config.cpp
@@ -48,11 +48,11 @@ void ConfigManager::save() {
 }
 
 void ConfigManager::enableAutoSave() {
-    if (!autoSaveEnabled) { autoSaveEnabled = true; }
+    autoSaveEnabled = true;
 }
 
 void ConfigManager::disableAutoSave() {
-    if (autoSaveEnabled) { autoSaveEnabled = false; }
+    autoSaveEnabled = false;
 }
 
 void ConfigManager::aquire() {

--- a/core/src/config.h
+++ b/core/src/config.h
@@ -1,9 +1,8 @@
 #pragma once
 #include <json.hpp>
-#include <thread>
+#include <atomic>
 #include <string>
 #include <mutex>
-#include <condition_variable>
 
 using nlohmann::json;
 
@@ -13,7 +12,7 @@ public:
     ~ConfigManager();
     void setPath(std::string file);
     void load(json def, bool lock = true);
-    void save(bool lock = true);
+    void save();
     void enableAutoSave();
     void disableAutoSave();
     void aquire();
@@ -22,16 +21,8 @@ public:
     json conf;
     
 private:
-    static void autoSaveWorker(ConfigManager* _this);
-
     std::string path = "";
-    bool changed = false;
-    bool autoSaveEnabled = false;
-    std::thread autoSaveThread;
+    std::atomic<bool> autoSaveEnabled = false;
+    std::chrono::time_point<std::chrono::system_clock> lastSave;
     std::mutex mtx;
-
-    std::mutex termMtx;
-    std::condition_variable termCond;
-    bool termFlag = false;
-
 };


### PR DESCRIPTION
I did not see necessity in having a worker thread, because you can just keep track of when the last save happened and compare it when releasing the config lock.