### PR TITLE
append build number to debian package version

### DIFF
--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -99,7 +99,7 @@ jobs:
           run: cd $GITHUB_WORKSPACE/docker_builds/debian_buster && docker build . --tag sdrpp_build
 
         - name: Run Container
-          run: docker run --name build sdrpp_build /root/do_build.sh
+          run: docker run --name build --env BUILD_NO="-$GITHUB_RUN_NUMBER" sdrpp_build /root/do_build.sh
 
         - name: Recover Deb Archive
           working-directory: ${{runner.workspace}}
@@ -121,7 +121,7 @@ jobs:
           run: cd $GITHUB_WORKSPACE/docker_builds/debian_bullseye && docker build . --tag sdrpp_build
 
         - name: Run Container
-          run: docker run --name build sdrpp_build /root/do_build.sh
+          run: docker run --name build --env BUILD_NO="-$GITHUB_RUN_NUMBER" sdrpp_build /root/do_build.sh
 
         - name: Recover Deb Archive
           working-directory: ${{runner.workspace}}
@@ -143,7 +143,7 @@ jobs:
           run: cd $GITHUB_WORKSPACE/docker_builds/debian_sid && docker build . --tag sdrpp_build
 
         - name: Run Container
-          run: docker run --name build sdrpp_build /root/do_build.sh
+          run: docker run --name build --env BUILD_NO="-$GITHUB_RUN_NUMBER" sdrpp_build /root/do_build.sh
 
         - name: Recover Deb Archive
           working-directory: ${{runner.workspace}}
@@ -165,7 +165,7 @@ jobs:
           run: cd $GITHUB_WORKSPACE/docker_builds/ubuntu_focal && docker build . --tag sdrpp_build
 
         - name: Run Container
-          run: docker run --name build sdrpp_build /root/do_build.sh
+          run: docker run --name build --env BUILD_NO="-$GITHUB_RUN_NUMBER" sdrpp_build /root/do_build.sh
 
         - name: Recover Deb Archive
           working-directory: ${{runner.workspace}}
@@ -187,7 +187,7 @@ jobs:
           run: cd $GITHUB_WORKSPACE/docker_builds/ubuntu_groovy && docker build . --tag sdrpp_build
 
         - name: Run Container
-          run: docker run --name build sdrpp_build /root/do_build.sh
+          run: docker run --name build --env BUILD_NO="-$GITHUB_RUN_NUMBER" sdrpp_build /root/do_build.sh
 
         - name: Recover Deb Archive
           working-directory: ${{runner.workspace}}
@@ -209,7 +209,7 @@ jobs:
           run: cd $GITHUB_WORKSPACE/docker_builds/ubuntu_hirsute && docker build . --tag sdrpp_build
 
         - name: Run Container
-          run: docker run --name build sdrpp_build /root/do_build.sh
+          run: docker run --name build --env BUILD_NO="-$GITHUB_RUN_NUMBER" sdrpp_build /root/do_build.sh
 
         - name: Recover Deb Archive
           working-directory: ${{runner.workspace}}

--- a/make_debian_package.sh
+++ b/make_debian_package.sh
@@ -8,7 +8,7 @@ mkdir sdrpp_debian_amd64/DEBIAN
 # Create package info
 echo Create package info
 echo Package: sdrpp >> sdrpp_debian_amd64/DEBIAN/control
-echo Version: 0.2.5 >> sdrpp_debian_amd64/DEBIAN/control
+echo Version: 0.2.5$BUILD_NO >> sdrpp_debian_amd64/DEBIAN/control
 echo Maintainer: Ryzerth >> sdrpp_debian_amd64/DEBIAN/control
 echo Architecture: all >> sdrpp_debian_amd64/DEBIAN/control
 echo Description: Bloat-free SDR receiver software >> sdrpp_debian_amd64/DEBIAN/control


### PR DESCRIPTION
Tested on my local machine, should work as long as the ENV variable is set:
```
~/SDRPlusPlus/docker_builds/debian_bullseye$ export GITHUB_RUN_NUMBER=109
~/SDRPlusPlus/docker_builds/debian_bullseye$ docker run --name build --env BUILD_NO="-$GITHUB_RUN_NUMBER" sdrpp_build /root/do_build.sh

...

~/SDRPlusPlus/docker_builds/debian_bullseye$ docker cp build:/root/SDRPlusPlus/sdrpp_debian_amd64.deb ./
~/SDRPlusPlus/docker_builds/debian_bullseye$ dpkg -I sdrpp_debian_amd64.deb 
 new Debian package, version 2.0.
 size 2370048 bytes: control archive=308 bytes.
     118 bytes,     5 lines      control              
 Package: sdrpp
 Version: 0.2.5-109
 Maintainer: Ryzerth
 Architecture: all
 Description: Bloat-free SDR receiver software

```
