### PR TITLE
Fix destructor crash due to wild pointer

### DIFF
--- a/core/src/dsp/buffer.h
+++ b/core/src/dsp/buffer.h
@@ -8,11 +8,7 @@ namespace dsp {
     template <class T>
     class RingBuffer {
     public:
-        RingBuffer():
-            _buffer{nullptr}
-        {
-
-        }
+        RingBuffer() {}
 
         RingBuffer(int maxLatency) { init(maxLatency); }
 
@@ -202,7 +198,7 @@ namespace dsp {
         }
 
     private:
-        T* _buffer;
+        T* _buffer = NULL;
         int size;
         int readc;
         int writec;

--- a/core/src/dsp/buffer.h
+++ b/core/src/dsp/buffer.h
@@ -8,7 +8,9 @@ namespace dsp {
     template <class T>
     class RingBuffer {
     public:
-        RingBuffer() {
+        RingBuffer():
+            _buffer{nullptr}
+        {
 
         }
 


### PR DESCRIPTION
Otherwise when RingBuffer is deleted before its init() being called it would crash in the destructor due to its _buffer pointer not being initialized.