### PR TITLE
Added error log to the HackRF start and stop calls

### DIFF
--- a/hackrf_source/src/main.cpp
+++ b/hackrf_source/src/main.cpp
@@ -228,8 +228,8 @@ private:
             return;
         }
 
-        auto err = static_cast<hackrf_error>(hackrf_open_by_serial(_this->selectedSerial.c_str(), &_this->openDev));
-        if (err != hackrf_error::HACKRF_SUCCESS) {
+        int err = hackrf_open_by_serial(_this->selectedSerial.c_str(), &_this->openDev);
+        if (err != HACKRF_SUCCESS) {
             spdlog::error("Could not open HackRF {0}: {1}", _this->selectedSerial, hackrf_error_name(err));
             return;
         }
@@ -257,8 +257,8 @@ private:
         _this->running = false;
         _this->stream.stopWriter();
         // TODO: Stream stop
-        auto err = static_cast<hackrf_error>(hackrf_close(_this->openDev));
-        if (err != hackrf_error::HACKRF_SUCCESS) {
+        int err = hackrf_close(_this->openDev);
+        if (err != HACKRF_SUCCESS) {
             spdlog::error("Could not close HackRF {0}: {1}", _this->selectedSerial, hackrf_error_name(err));
         }
         _this->stream.clearWriteStop();

--- a/hackrf_source/src/main.cpp
+++ b/hackrf_source/src/main.cpp
@@ -228,9 +228,9 @@ private:
             return;
         }
 
-        int err = hackrf_open_by_serial(_this->selectedSerial.c_str(), &_this->openDev);
-        if (err != 0) {
-            spdlog::error("Could not open HackRF {0}", _this->selectedSerial);
+        auto err = static_cast<hackrf_error>(hackrf_open_by_serial(_this->selectedSerial.c_str(), &_this->openDev));
+        if (err != hackrf_error::HACKRF_SUCCESS) {
+            spdlog::error("Could not open HackRF {0}: {1}", _this->selectedSerial, hackrf_error_name(err));
             return;
         }
 
@@ -257,7 +257,10 @@ private:
         _this->running = false;
         _this->stream.stopWriter();
         // TODO: Stream stop
-        hackrf_close(_this->openDev);
+        auto err = static_cast<hackrf_error>(hackrf_close(_this->openDev));
+        if (err != hackrf_error::HACKRF_SUCCESS) {
+            spdlog::error("Could not close HackRF {0}: {1}", _this->selectedSerial, hackrf_error_name(err));
+        }
         _this->stream.clearWriteStop();
         spdlog::info("HackRFSourceModule '{0}': Stop!", _this->name);
     }


### PR DESCRIPTION
The libhackrf fails to close the device properly which makes the entire lib crash when trying to start it again after that.
When the device is not closed correctly, we exit/init the libhackrf again to make sure it is in a state that will allow starting again later on. This probably will require more investigation on the root cause...