### PR TITLE
Set SO_REUSEADDR option to listen sockets on non-Windows systems

### DIFF
--- a/core/src/utils/networking.cpp
+++ b/core/src/utils/networking.cpp
@@ -371,6 +371,18 @@ namespace net {
             return NULL;
         }
 
+#ifndef _WIN32
+        // Allow port reusing if the app was killed or crashed 
+        // and the socket is stuck in TIME_WAIT state.
+        // This option has a different meaning on Windows, 
+        // so we use it only for non-Windows systems
+        int enable = 1;
+        if (setsockopt(listenSock, SOL_SOCKET, SO_REUSEADDR, &enable, sizeof (int)) < 0) {
+            throw std::runtime_error("Could not configure socket");
+            return NULL;            
+        }
+#endif
+
         // Get address from hostname/ip
         hostent* remoteHost = gethostbyname(host.c_str());
         if (remoteHost == NULL || remoteHost->h_addr_list[0] == NULL) {


### PR DESCRIPTION
Currently, SDR++ on Linux fails to start rigctl server for some time after the app restart if there were active rigctl client connections at the app exit, particularly when SDR++ was killed by a signal. In this case, the rigctl server socket will be stuck in TIME_WAIT state for quite some time and by default, the kernel is not allowing to bind a socket to the port if there are already bound sockets with the same port number. This patch sets SO_REUSEADDR socket option to listen socket, which explicitly allows a process to bind to a port that remains in TIME_WAIT state. Since this option has a different meaning on Windows systems, it is applied only for non-Windows builds.