### PR TITLE
MacOS Airspy HF support

### DIFF
--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -12,7 +12,7 @@ jobs:
 
         steps:
         - uses: actions/checkout@v2
-        
+
         - name: Create Build Environment
           run: cmake -E make_directory ${{runner.workspace}}/build
 
@@ -28,7 +28,7 @@ jobs:
         - name: Patch Pothos with earlier libusb version
           working-directory: ${{runner.workspace}}
           run: 7z x libusb.7z -olibusb_old ; rm "C:/Program Files/PothosSDR/bin/libusb-1.0.dll" ; cp "libusb_old/MS64/dll/libusb-1.0.dll" "C:/Program Files/PothosSDR/bin/"
- 
+
         - name: Download SDRPlay API
           run: Invoke-WebRequest -Uri "https://drive.google.com/uc?id=12UHPMwkfa67A11QZDmpCT4iwHnyJHWuu" -OutFile ${{runner.workspace}}/SDRPlay.zip
 
@@ -64,16 +64,19 @@ jobs:
 
         steps:
         - uses: actions/checkout@v2
-        
+
         - name: Create Build Environment
           run: cmake -E make_directory ${{runner.workspace}}/build
 
+        - name: Update Homebrew
+          run: brew update
+
         - name: Install dependencies
-          run: brew install fftw glew glfw volk airspy portaudio hackrf rtl-sdr libbladerf
+          run: brew install fftw glew glfw volk airspy airspyhf portaudio hackrf rtl-sdr libbladerf
 
         - name: Prepare CMake
           working-directory: ${{runner.workspace}}/build
-          run: cmake $GITHUB_WORKSPACE -DOPT_BUILD_AIRSPYHF_SOURCE=OFF -DOPT_BUILD_PLUTOSDR_SOURCE=OFF -DOPT_BUILD_SOAPY_SOURCE=OFF -DOPT_BUILD_BLADERF_SOURCE=OFF -DOPT_BUILD_AUDIO_SINK=OFF -DOPT_BUILD_PORTAUDIO_SINK=ON -DOPT_BUILD_NEW_PORTAUDIO_SINK=ON
+          run: cmake $GITHUB_WORKSPACE -DOPT_BUILD_AIRSPYHF_SOURCE=ON -DOPT_BUILD_PLUTOSDR_SOURCE=OFF -DOPT_BUILD_SOAPY_SOURCE=OFF -DOPT_BUILD_BLADERF_SOURCE=OFF -DOPT_BUILD_AUDIO_SINK=OFF -DOPT_BUILD_PORTAUDIO_SINK=ON -DOPT_BUILD_NEW_PORTAUDIO_SINK=ON
 
         - name: Build
           working-directory: ${{runner.workspace}}/build
@@ -88,13 +91,13 @@ jobs:
           with:
               name: sdrpp_macos_amd64
               path: ${{runner.workspace}}/sdrpp_macos_amd64.pkg
-  
+
     build_debian_buster:
         runs-on: ubuntu-latest
 
         steps:
         - uses: actions/checkout@v2
-        
+
         - name: Create Docker Image
           run: cd $GITHUB_WORKSPACE/docker_builds/debian_buster && docker build . --tag sdrpp_build
 
@@ -116,7 +119,7 @@ jobs:
 
         steps:
         - uses: actions/checkout@v2
-        
+
         - name: Create Docker Image
           run: cd $GITHUB_WORKSPACE/docker_builds/debian_bullseye && docker build . --tag sdrpp_build
 
@@ -138,7 +141,7 @@ jobs:
 
         steps:
         - uses: actions/checkout@v2
-        
+
         - name: Create Docker Image
           run: cd $GITHUB_WORKSPACE/docker_builds/debian_sid && docker build . --tag sdrpp_build
 
@@ -160,7 +163,7 @@ jobs:
 
         steps:
         - uses: actions/checkout@v2
-        
+
         - name: Create Docker Image
           run: cd $GITHUB_WORKSPACE/docker_builds/ubuntu_bionic && docker build . --tag sdrpp_build
 
@@ -182,7 +185,7 @@ jobs:
 
         steps:
         - uses: actions/checkout@v2
-        
+
         - name: Create Docker Image
           run: cd $GITHUB_WORKSPACE/docker_builds/ubuntu_focal && docker build . --tag sdrpp_build
 
@@ -204,7 +207,7 @@ jobs:
 
         steps:
         - uses: actions/checkout@v2
-        
+
         - name: Create Docker Image
           run: cd $GITHUB_WORKSPACE/docker_builds/ubuntu_groovy && docker build . --tag sdrpp_build
 
@@ -226,7 +229,7 @@ jobs:
 
         steps:
         - uses: actions/checkout@v2
-        
+
         - name: Create Docker Image
           run: cd $GITHUB_WORKSPACE/docker_builds/ubuntu_hirsute && docker build . --tag sdrpp_build
 
@@ -242,7 +245,7 @@ jobs:
           with:
               name: sdrpp_ubuntu_hirsute_amd64
               path: ${{runner.workspace}}/sdrpp_debian_amd64.deb
-    
+
     create_full_archive:
         needs: ['build_windows', 'build_macos', 'build_debian_buster', 'build_debian_bullseye', 'build_debian_sid', 'build_ubuntu_bionic', 'build_ubuntu_focal', 'build_ubuntu_groovy', 'build_ubuntu_hirsute']
         runs-on: ubuntu-latest
@@ -253,15 +256,15 @@ jobs:
 
         - name: Create Archive
           run: >
-            mkdir sdrpp_all && 
-            mv sdrpp_windows_x64/sdrpp_windows_x64.zip sdrpp_all/ && 
-            mv sdrpp_macos_amd64/sdrpp_macos_amd64.pkg sdrpp_all/ && 
-            mv sdrpp_debian_buster_amd64/sdrpp_debian_amd64.deb sdrpp_all/sdrpp_debian_buster_amd64.deb && 
-            mv sdrpp_debian_bullseye_amd64/sdrpp_debian_amd64.deb sdrpp_all/sdrpp_debian_bullseye_amd64.deb && 
-            mv sdrpp_debian_sid_amd64/sdrpp_debian_amd64.deb sdrpp_all/sdrpp_debian_sid_amd64.deb && 
-            mv sdrpp_ubuntu_bionic_amd64/sdrpp_debian_amd64.deb sdrpp_all/sdrpp_ubuntu_bionic_amd64.deb && 
-            mv sdrpp_ubuntu_focal_amd64/sdrpp_debian_amd64.deb sdrpp_all/sdrpp_ubuntu_focal_amd64.deb && 
-            mv sdrpp_ubuntu_groovy_amd64/sdrpp_debian_amd64.deb sdrpp_all/sdrpp_ubuntu_groovy_amd64.deb && 
+            mkdir sdrpp_all &&
+            mv sdrpp_windows_x64/sdrpp_windows_x64.zip sdrpp_all/ &&
+            mv sdrpp_macos_amd64/sdrpp_macos_amd64.pkg sdrpp_all/ &&
+            mv sdrpp_debian_buster_amd64/sdrpp_debian_amd64.deb sdrpp_all/sdrpp_debian_buster_amd64.deb &&
+            mv sdrpp_debian_bullseye_amd64/sdrpp_debian_amd64.deb sdrpp_all/sdrpp_debian_bullseye_amd64.deb &&
+            mv sdrpp_debian_sid_amd64/sdrpp_debian_amd64.deb sdrpp_all/sdrpp_debian_sid_amd64.deb &&
+            mv sdrpp_ubuntu_bionic_amd64/sdrpp_debian_amd64.deb sdrpp_all/sdrpp_ubuntu_bionic_amd64.deb &&
+            mv sdrpp_ubuntu_focal_amd64/sdrpp_debian_amd64.deb sdrpp_all/sdrpp_ubuntu_focal_amd64.deb &&
+            mv sdrpp_ubuntu_groovy_amd64/sdrpp_debian_amd64.deb sdrpp_all/sdrpp_ubuntu_groovy_amd64.deb &&
             mv sdrpp_ubuntu_hirsute_amd64/sdrpp_debian_amd64.deb sdrpp_all/sdrpp_ubuntu_hirsute_amd64.deb
 
         - uses: actions/upload-artifact@v2


### PR DESCRIPTION
Yesterday Homebrew accepted my pull request for `airspyhf`.
Since the `airspyhf` was added only yesterday, I had to add brew update in `build_macos`.

And sorry for auto formatting of build_all.yml, my VSCode always delete whitespaces after file save.