### PR TITLE
soapy_source: always show the Refresh button

### DIFF
--- a/soapy_source/src/main.cpp
+++ b/soapy_source/src/main.cpp
@@ -353,13 +353,18 @@ private:
     
     static void menuHandler(void* ctx) {
         SoapyModule* _this = (SoapyModule*)ctx;
-        
-        // If no device is available, do not attempt to display menu
-        if (_this->devId < 0) {
-            return;
-        }
 
         float menuWidth = ImGui::GetContentRegionAvailWidth();
+        
+        // If no device is selected, draw just the refresh button
+        if (_this->devId < 0) {
+            if (ImGui::Button(CONCAT("Refresh##_dev_select_", _this->name), ImVec2(menuWidth, 0))) {
+                _this->refresh();
+                _this->selectDevice(config.conf["device"]);
+            }
+
+            return;
+        }
 
         if (_this->running) { style::beginDisabled(); }
 

--- a/soapy_source/src/main.cpp
+++ b/soapy_source/src/main.cpp
@@ -356,13 +356,12 @@ private:
 
         float menuWidth = ImGui::GetContentRegionAvailWidth();
         
-        // If no device is selected, draw just the refresh button
+        // If no device is selected, draw only the refresh button
         if (_this->devId < 0) {
             if (ImGui::Button(CONCAT("Refresh##_dev_select_", _this->name), ImVec2(menuWidth, 0))) {
                 _this->refresh();
                 _this->selectDevice(config.conf["device"]);
             }
-
             return;
         }
 


### PR DESCRIPTION
When SDR++ starts with no devices found by Soapy, there is no Refresh button and you need to restart the app to be able to select any. This makes the Refresh button always visible.

![2021-08-30_00-14_1](https://user-images.githubusercontent.com/7243565/131266983-57b95279-b577-4914-ac08-1d518a9afffc.png)
After connecting a device and clicking the button:
![2021-08-30_00-14](https://user-images.githubusercontent.com/7243565/131266982-bdf883a5-d502-4d6c-939a-b47a664032c0.png)

