### PR TITLE
soapy_source: refresh devices on start if none in devList

### DIFF
--- a/soapy_source/src/main.cpp
+++ b/soapy_source/src/main.cpp
@@ -296,6 +296,14 @@ private:
     static void start(void* ctx) {
         SoapyModule* _this = (SoapyModule*)ctx;
         if (_this->running) { return; }
+        if (_this->devId < 0) {
+            _this->refresh();
+            _this->selectDevice(config.conf["device"]);
+            if (_this->devId < 0) {
+                return;
+            }
+        }
+
         _this->dev = SoapySDR::Device::make(_this->devArgs);
 
         _this->dev->setSampleRate(SOAPY_SDR_RX, _this->channelId, _this->sampleRate);

--- a/soapy_source/src/main.cpp
+++ b/soapy_source/src/main.cpp
@@ -297,11 +297,7 @@ private:
         SoapyModule* _this = (SoapyModule*)ctx;
         if (_this->running) { return; }
         if (_this->devId < 0) {
-            _this->refresh();
-            _this->selectDevice(config.conf["device"]);
-            if (_this->devId < 0) {
-                return;
-            }
+            return;
         }
 
         _this->dev = SoapySDR::Device::make(_this->devArgs);

--- a/soapy_source/src/main.cpp
+++ b/soapy_source/src/main.cpp
@@ -297,6 +297,7 @@ private:
         SoapyModule* _this = (SoapyModule*)ctx;
         if (_this->running) { return; }
         if (_this->devId < 0) {
+            spdlog::error("No device available");
             return;
         }
 


### PR DESCRIPTION
If there are no devices in the device list enumerated when the application starts, clicking the play button causes the whole app to crash (probably because of nullptr in devList). This tries to ask Soapy for devices before giving up gracefully, providing smoother experience to the user and preventing the crash.

Clicking the play button, however, still makes SDR++ think it's running. There is no feedback between source modules and the main app. Some interface should be made to return status data to the app for proper state keeping.