### PR TITLE
Make the zoom slider exponential

### DIFF
--- a/core/src/gui/main_window.cpp
+++ b/core/src/gui/main_window.cpp
@@ -598,8 +598,14 @@ void MainWindow::draw() {
     ImGui::SetCursorPosX((ImGui::GetWindowSize().x / 2.0) - (ImGui::CalcTextSize("Zoom").x / 2.0));
     ImGui::Text("Zoom");
     ImGui::SetCursorPosX((ImGui::GetWindowSize().x / 2.0) - 10);
-    if (ImGui::VSliderFloat("##_7_", ImVec2(20.0, 150.0), &bw, gui::waterfall.getBandwidth(), 1000.0, "")) {
-        gui::waterfall.setViewBandwidth(bw);
+    float minSliderBw = 1000.0;
+    float maxSliderBw = gui::waterfall.getBandwidth();
+    if (ImGui::VSliderFloat("##_7_", ImVec2(20.0, 150.0), &bw, maxSliderBw, minSliderBw, "")) {
+        float normBw = bw / (maxSliderBw - minSliderBw);
+        float factor = normBw * normBw;
+        float finalBw = minSliderBw + bw * factor;
+
+        gui::waterfall.setViewBandwidth(finalBw);
         if (vfo != NULL) {
             gui::waterfall.setViewOffset(vfo->centerOffset); // center vfo on screen
         }


### PR DESCRIPTION
Zooming on signals with small bandwidth on a scope of 10 MHz is a pain with linear slider. If the selected bandwidth is made to grow exponentially, it provides finer control towards the lower end of the range while maintaining enough granularity in the upper range.

This makes zooming, one of the most frequently touched control in the whole program, much more useful. Instead of having to grip my mouse and try to work inside 5 pixels to get a good look at a signal, I can now comfortably zoom in and out.