### PR TITLE
Frequency manager channel hopper

### DIFF
--- a/frequency_manager/src/main.cpp
+++ b/frequency_manager/src/main.cpp
@@ -137,9 +137,8 @@ private:
     static void applyBookmark(FrequencyBookmark bm, std::string vfoName) {
         if (vfoName == "") {
             // TODO: Replace with proper tune call
-            gui::waterfall.setCenterFrequency(bm.frequency + 500000);
+            gui::waterfall.setCenterFrequency(bm.frequency);
             gui::waterfall.centerFreqMoved = true;
-            tuner::tune(tuner::TUNER_MODE_NORMAL, gui::waterfall.selectedVFO, bm.frequency);
         }
         else {
             if (core::modComManager.interfaceExists(vfoName)) {


### PR DESCRIPTION
I don't know if anyone wants this or not, but I hacked up a way to do channel-hopping between stored frequencies in the Frequency Manager plug-in.  It limits itself to just channels that are within the current view and adds a simple "scan channels in view" checkbox to the Frequency Manger UI to toggle it.