### PR TITLE
Make Windows includes lowercase for MinGW

### DIFF
--- a/core/src/core.cpp
+++ b/core/src/core.cpp
@@ -26,7 +26,7 @@
 #include <signal_path/signal_path.h>
 
 #ifdef _WIN32
-#include <Windows.h>
+#include <windows.h>
 #endif
 
 #ifndef INSTALL_PREFIX

--- a/core/src/gui/file_dialogs.h
+++ b/core/src/gui/file_dialogs.h
@@ -16,10 +16,10 @@
 #ifndef WIN32_LEAN_AND_MEAN
 #   define WIN32_LEAN_AND_MEAN 1
 #endif
-#include <Windows.h>
+#include <windows.h>
 #include <commdlg.h>
-#include <ShlObj.h>
-#include <ShObjIdl.h> // IFileDialog
+#include <shlobj.h>
+#include <shobjidl.h> // IFileDialog
 #include <shellapi.h>
 #include <strsafe.h>
 #include <future>     // std::async

--- a/core/src/imgui/imgui.cpp
+++ b/core/src/imgui/imgui.cpp
@@ -797,7 +797,7 @@ CODE
 #define NOMINMAX
 #endif
 #ifndef __MINGW32__
-#include <Windows.h>        // _wfopen, OpenClipboard
+#include <windows.h>        // _wfopen, OpenClipboard
 #else
 #include <windows.h>
 #endif

--- a/core/src/module.h
+++ b/core/src/module.h
@@ -15,7 +15,7 @@
 #endif
 
 #ifdef _WIN32
-    #include <Windows.h>
+    #include <windows.h>
     #define MOD_EXPORT extern "C" __declspec(dllexport)
     #define SDRPP_MOD_EXTENTSION    ".dll"
 #else

--- a/core/src/utils/networking.h
+++ b/core/src/utils/networking.h
@@ -9,8 +9,8 @@
 #include <condition_variable>
 
 #ifdef _WIN32
-#include <WinSock2.h>
-#include <WS2tcpip.h>
+#include <winsock2.h>
+#include <ws2tcpip.h>
 #else
 #include <unistd.h>
 #include <strings.h>

--- a/rtl_tcp_source/src/rtltcp_client.h
+++ b/rtl_tcp_source/src/rtltcp_client.h
@@ -4,8 +4,8 @@
 #include <inttypes.h>
 
 #ifdef _WIN32
-#include <WinSock2.h>
-#include <WS2tcpip.h>
+#include <winsock2.h>
+#include <ws2tcpip.h>
 #else
 #include <unistd.h>
 #include <strings.h>


### PR DESCRIPTION
MinGW-w64 ships all Windows SDK headers as lowercase, which prevents
cross-compiling this code from Linux.

Windows filesystems are case insensitive so it should work fine with
lowercase includes.