### PR TITLE
Use CMAKE_INSTALL_FULL_LIBDIR instead of hardcoding lib

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -117,4 +117,4 @@ set(CORE_FILES ${RUNTIME_OUTPUT_DIRECTORY} PARENT_SCOPE)
 # cmake .. "-DCMAKE_TOOLCHAIN_FILE=C:/dev/vcpkg/scripts/buildsystems/vcpkg.cmake"
 
 # Install directives
-install(TARGETS sdrpp_core DESTINATION lib)
+install(TARGETS sdrpp_core DESTINATION ${CMAKE_INSTALL_FULL_LIBDIR})

--- a/decoder_modules/falcon9_decoder/CMakeLists.txt
+++ b/decoder_modules/falcon9_decoder/CMakeLists.txt
@@ -18,4 +18,4 @@ else ()
 endif ()
 
 # Install directives
-install(TARGETS falcon9_decoder DESTINATION lib/sdrpp/plugins)
+install(TARGETS falcon9_decoder DESTINATION ${CMAKE_INSTALL_FULL_LIBDIR}/sdrpp/plugins)

--- a/decoder_modules/m17_decoder/CMakeLists.txt
+++ b/decoder_modules/m17_decoder/CMakeLists.txt
@@ -43,4 +43,4 @@ endif ()
 
 
 # Install directives
-install(TARGETS m17_decoder DESTINATION lib/sdrpp/plugins)
+install(TARGETS m17_decoder DESTINATION ${CMAKE_INSTALL_FULL_LIBDIR}/sdrpp/plugins)

--- a/decoder_modules/meteor_demodulator/CMakeLists.txt
+++ b/decoder_modules/meteor_demodulator/CMakeLists.txt
@@ -18,4 +18,4 @@ else ()
 endif ()
 
 # Install directives
-install(TARGETS meteor_demodulator DESTINATION lib/sdrpp/plugins)
+install(TARGETS meteor_demodulator DESTINATION ${CMAKE_INSTALL_FULL_LIBDIR}/sdrpp/plugins)

--- a/decoder_modules/radio/CMakeLists.txt
+++ b/decoder_modules/radio/CMakeLists.txt
@@ -18,4 +18,4 @@ else ()
 endif ()
 
 # Install directives
-install(TARGETS radio DESTINATION lib/sdrpp/plugins)
+install(TARGETS radio DESTINATION ${CMAKE_INSTALL_FULL_LIBDIR}/sdrpp/plugins)

--- a/decoder_modules/weather_sat_decoder/CMakeLists.txt
+++ b/decoder_modules/weather_sat_decoder/CMakeLists.txt
@@ -18,4 +18,4 @@ else ()
 endif ()
 
 # Install directives
-install(TARGETS weather_sat_decoder DESTINATION lib/sdrpp/plugins)
+install(TARGETS weather_sat_decoder DESTINATION ${CMAKE_INSTALL_FULL_LIBDIR}/sdrpp/plugins)

--- a/misc_modules/demo_module/CMakeLists.txt
+++ b/misc_modules/demo_module/CMakeLists.txt
@@ -18,4 +18,4 @@ else ()
 endif ()
 
 # Install directives
-install(TARGETS demo DESTINATION lib/sdrpp/plugins)
+install(TARGETS demo DESTINATION ${CMAKE_INSTALL_FULL_LIBDIR}/sdrpp/plugins)

--- a/misc_modules/discord_integration/CMakeLists.txt
+++ b/misc_modules/discord_integration/CMakeLists.txt
@@ -26,4 +26,4 @@ else ()
 endif ()
 
 # Install directives
-install(TARGETS discord_integration DESTINATION lib/sdrpp/plugins)
+install(TARGETS discord_integration DESTINATION ${CMAKE_INSTALL_FULL_LIBDIR}/sdrpp/plugins)

--- a/misc_modules/frequency_manager/CMakeLists.txt
+++ b/misc_modules/frequency_manager/CMakeLists.txt
@@ -18,4 +18,4 @@ else ()
 endif ()
 
 # Install directives
-install(TARGETS frequency_manager DESTINATION lib/sdrpp/plugins)
+install(TARGETS frequency_manager DESTINATION ${CMAKE_INSTALL_FULL_LIBDIR}/sdrpp/plugins)

--- a/misc_modules/recorder/CMakeLists.txt
+++ b/misc_modules/recorder/CMakeLists.txt
@@ -18,4 +18,4 @@ else ()
 endif ()
 
 # Install directives
-install(TARGETS recorder DESTINATION lib/sdrpp/plugins)
+install(TARGETS recorder DESTINATION ${CMAKE_INSTALL_FULL_LIBDIR}/sdrpp/plugins)

--- a/misc_modules/rigctl_server/CMakeLists.txt
+++ b/misc_modules/rigctl_server/CMakeLists.txt
@@ -21,4 +21,4 @@ else ()
 endif ()
 
 # Install directives
-install(TARGETS rigctl_server DESTINATION lib/sdrpp/plugins)
+install(TARGETS rigctl_server DESTINATION ${CMAKE_INSTALL_FULL_LIBDIR}/sdrpp/plugins)

--- a/misc_modules/scanner/CMakeLists.txt
+++ b/misc_modules/scanner/CMakeLists.txt
@@ -18,4 +18,4 @@ else ()
 endif ()
 
 # Install directives
-install(TARGETS scanner DESTINATION lib/sdrpp/plugins)
+install(TARGETS scanner DESTINATION ${CMAKE_INSTALL_FULL_LIBDIR}/sdrpp/plugins)

--- a/sink_modules/audio_sink/CMakeLists.txt
+++ b/sink_modules/audio_sink/CMakeLists.txt
@@ -37,4 +37,4 @@ else (MSVC)
 endif ()
 
 # Install directives
-install(TARGETS audio_sink DESTINATION lib/sdrpp/plugins)
+install(TARGETS audio_sink DESTINATION ${CMAKE_INSTALL_FULL_LIBDIR}/sdrpp/plugins)

--- a/sink_modules/network_sink/CMakeLists.txt
+++ b/sink_modules/network_sink/CMakeLists.txt
@@ -18,4 +18,4 @@ else ()
 endif ()
 
 # Install directives
-install(TARGETS network_sink DESTINATION lib/sdrpp/plugins)
+install(TARGETS network_sink DESTINATION ${CMAKE_INSTALL_FULL_LIBDIR}/sdrpp/plugins)

--- a/sink_modules/new_portaudio_sink/CMakeLists.txt
+++ b/sink_modules/new_portaudio_sink/CMakeLists.txt
@@ -34,4 +34,4 @@ else (MSVC)
 endif (MSVC)
 
 # Install directives
-install(TARGETS new_portaudio_sink DESTINATION lib/sdrpp/plugins)
+install(TARGETS new_portaudio_sink DESTINATION ${CMAKE_INSTALL_FULL_LIBDIR}/sdrpp/plugins)

--- a/sink_modules/portaudio_sink/CMakeLists.txt
+++ b/sink_modules/portaudio_sink/CMakeLists.txt
@@ -34,4 +34,4 @@ else (MSVC)
 endif (MSVC)
 
 # Install directives
-install(TARGETS audio_sink DESTINATION lib/sdrpp/plugins)
+install(TARGETS audio_sink DESTINATION ${CMAKE_INSTALL_FULL_LIBDIR}/sdrpp/plugins)

--- a/source_modules/airspy_source/CMakeLists.txt
+++ b/source_modules/airspy_source/CMakeLists.txt
@@ -39,4 +39,4 @@ else (MSVC)
 endif ()
 
 # Install directives
-install(TARGETS airspy_source DESTINATION lib/sdrpp/plugins)
+install(TARGETS airspy_source DESTINATION ${CMAKE_INSTALL_FULL_LIBDIR}/sdrpp/plugins)

--- a/source_modules/airspyhf_source/CMakeLists.txt
+++ b/source_modules/airspyhf_source/CMakeLists.txt
@@ -39,4 +39,4 @@ else (MSVC)
 endif ()
 
 # Install directives
-install(TARGETS airspyhf_source DESTINATION lib/sdrpp/plugins)
+install(TARGETS airspyhf_source DESTINATION ${CMAKE_INSTALL_FULL_LIBDIR}/sdrpp/plugins)

--- a/source_modules/bladerf_source/CMakeLists.txt
+++ b/source_modules/bladerf_source/CMakeLists.txt
@@ -33,4 +33,4 @@ else (MSVC)
 endif ()
 
 # Install directives
-install(TARGETS bladerf_source DESTINATION lib/sdrpp/plugins)
+install(TARGETS bladerf_source DESTINATION ${CMAKE_INSTALL_FULL_LIBDIR}/sdrpp/plugins)

--- a/source_modules/file_source/CMakeLists.txt
+++ b/source_modules/file_source/CMakeLists.txt
@@ -18,4 +18,4 @@ else ()
 endif ()
 
 # Install directives
-install(TARGETS file_source DESTINATION lib/sdrpp/plugins)
+install(TARGETS file_source DESTINATION ${CMAKE_INSTALL_FULL_LIBDIR}/sdrpp/plugins)

--- a/source_modules/hackrf_source/CMakeLists.txt
+++ b/source_modules/hackrf_source/CMakeLists.txt
@@ -33,4 +33,4 @@ else (MSVC)
 endif ()
 
 # Install directives
-install(TARGETS hackrf_source DESTINATION lib/sdrpp/plugins)
+install(TARGETS hackrf_source DESTINATION ${CMAKE_INSTALL_FULL_LIBDIR}/sdrpp/plugins)

--- a/source_modules/limesdr_source/CMakeLists.txt
+++ b/source_modules/limesdr_source/CMakeLists.txt
@@ -35,4 +35,4 @@ else (MSVC)
 endif ()
 
 # Install directives
-install(TARGETS limesdr_source DESTINATION lib/sdrpp/plugins)
+install(TARGETS limesdr_source DESTINATION ${CMAKE_INSTALL_FULL_LIBDIR}/sdrpp/plugins)

--- a/source_modules/plutosdr_source/CMakeLists.txt
+++ b/source_modules/plutosdr_source/CMakeLists.txt
@@ -40,4 +40,4 @@ else (MSVC)
 endif ()
 
 # Install directives
-install(TARGETS plutosdr_source DESTINATION lib/sdrpp/plugins)
+install(TARGETS plutosdr_source DESTINATION ${CMAKE_INSTALL_FULL_LIBDIR}/sdrpp/plugins)

--- a/source_modules/rtl_sdr_source/CMakeLists.txt
+++ b/source_modules/rtl_sdr_source/CMakeLists.txt
@@ -34,4 +34,4 @@ else (MSVC)
 endif ()
 
 # Install directives
-install(TARGETS rtl_sdr_source DESTINATION lib/sdrpp/plugins)
+install(TARGETS rtl_sdr_source DESTINATION ${CMAKE_INSTALL_FULL_LIBDIR}/sdrpp/plugins)

--- a/source_modules/rtl_tcp_source/CMakeLists.txt
+++ b/source_modules/rtl_tcp_source/CMakeLists.txt
@@ -22,4 +22,4 @@ if(WIN32)
 endif()
 
 # Install directives
-install(TARGETS rtl_tcp_source DESTINATION lib/sdrpp/plugins)
+install(TARGETS rtl_tcp_source DESTINATION ${CMAKE_INSTALL_FULL_LIBDIR}/sdrpp/plugins)

--- a/source_modules/sddc_source/CMakeLists.txt
+++ b/source_modules/sddc_source/CMakeLists.txt
@@ -42,4 +42,4 @@ else (MSVC)
 endif ()
 
 # Install directives
-install(TARGETS sddc_source DESTINATION lib/sdrpp/plugins)
+install(TARGETS sddc_source DESTINATION ${CMAKE_INSTALL_FULL_LIBDIR}/sdrpp/plugins)

--- a/source_modules/sdrplay_source/CMakeLists.txt
+++ b/source_modules/sdrplay_source/CMakeLists.txt
@@ -36,4 +36,4 @@ else (MSVC)
 endif ()
 
 # Install directives
-install(TARGETS sdrplay_source DESTINATION lib/sdrpp/plugins)
+install(TARGETS sdrplay_source DESTINATION ${CMAKE_INSTALL_FULL_LIBDIR}/sdrpp/plugins)

--- a/source_modules/soapy_source/CMakeLists.txt
+++ b/source_modules/soapy_source/CMakeLists.txt
@@ -36,4 +36,4 @@ else (MSVC)
 endif ()
 
 # Install directives
-install(TARGETS soapy_source DESTINATION lib/sdrpp/plugins)
+install(TARGETS soapy_source DESTINATION ${CMAKE_INSTALL_FULL_LIBDIR}/sdrpp/plugins)

--- a/source_modules/spyserver_source/CMakeLists.txt
+++ b/source_modules/spyserver_source/CMakeLists.txt
@@ -22,4 +22,4 @@ if(WIN32)
 endif()
 
 # Install directives
-install(TARGETS spyserver_source DESTINATION lib/sdrpp/plugins)
+install(TARGETS spyserver_source DESTINATION ${CMAKE_INSTALL_FULL_LIBDIR}/sdrpp/plugins)


### PR DESCRIPTION

This prevents Gentoo's Portage from throwing strict-multilib errors as Gentoo only expects 32-bit libraries in lib and 64-bit libraries in lib64

This should not effect building on other distributions as cmake will set CMAKE_INSTALL_FULL_LIBDIR appropriately.