### PR TITLE
Bandplan for austria

### DIFF
--- a/root/res/bandplans/austria.json
+++ b/root/res/bandplans/austria.json
@@ -1,0 +1,141 @@
+{
+    "name": "Austria",
+    "country_name": "Austria",
+    "country_code": "AT",
+    "author_name": "Michael Mangeng",
+    "author_url": "https://vis.at",
+    "bands": [
+        {
+            "name": "LW",
+            "type": "amateur",
+            "start": 135700,
+            "end": 137800
+        },
+        {
+            "name": "630m",
+            "type": "amateur",
+            "start": 472000,
+            "end": 479000
+        },
+        {
+            "name": "160m",
+            "type": "amateur",
+            "start": 1810000,
+            "end": 1950000
+        },
+        {
+            "name": "80m",
+            "type": "amateur",
+            "start": 3500000,
+            "end": 3800000
+        },
+        {
+            "name": "60m",
+            "type": "amateur",
+            "start": 5351300,
+            "end": 5366500
+        },
+        {
+            "name": "40m",
+            "type": "amateur",
+            "start": 7000000,
+            "end": 7200000
+        },
+        {
+            "name": "30m",
+            "type": "amateur",
+            "start": 10100000,
+            "end": 10150000
+        },
+        {
+            "name": "20m",
+            "type": "amateur",
+            "start": 14000000,
+            "end": 14350000
+        },
+        {
+            "name": "17m",
+            "type": "amateur",
+            "start": 18068000,
+            "end": 18168000
+        },
+        {
+            "name": "15m",
+            "type": "amateur",
+            "start": 21000000,
+            "end": 21450000
+        },
+        {
+            "name": "12m",
+            "type": "amateur",
+            "start": 24890000,
+            "end": 24990000
+        },
+        {
+            "name": "CB",
+            "type": "other",
+            "start": 26965000,
+            "end": 27405000
+        },
+        {
+            "name": "10m",
+            "type": "amateur",
+            "start": 28000000,
+            "end": 29700000
+        },
+        {
+            "name": "6m",
+            "type": "amateur",
+            "start": 50000000,
+            "end": 52000000
+        },
+        {
+            "name": "FM",
+            "type": "broadcast",
+            "start": 87500000,
+            "end": 108000000
+        },
+        {
+            "name": "2m",
+            "type": "amateur",
+            "start": 144000000,
+            "end": 146000000
+        },
+        {
+            "name": "Freenet",
+            "type": "other",
+            "start": 149025000,
+            "end": 149115625
+        },
+        {
+            "name": "70cm",
+            "type": "amateur",
+            "start": 430000000,
+            "end": 440000000
+        },
+        {
+            "name": "PMR446",
+            "type": "other",
+            "start": 446006250,
+            "end": 446196875
+        },
+        {
+            "name": "23cm",
+            "type": "amateur",
+            "start": 1240000000,
+            "end": 1300000000
+        },
+        {
+            "name": "13cm",
+            "type": "amateur",
+            "start": 2304000000,
+            "end":   2310000000
+        },
+        {
+            "name": "13cm",
+            "type": "amateur",
+            "start": 2320000000,
+            "end":   2322000000
+        }
+    ]
+}


### PR DESCRIPTION
Share ham radio bandplan for Austria - according to government document 'Amateurfunkverordnung' / 'Anlage 2' located at:
https://www.ris.bka.gv.at/NormDokument.wxe?Abfrage=Bundesnormen&Gesetzesnummer=10012930&Artikel=&Paragraf=&Anlage=2&Uebergangsrecht=

(As for the bandplan for germany, i skipped the ISM and SAT bands)