### PR TITLE
[libcorrect] initialize bestpath to 0

### DIFF
--- a/core/libcorrect/src/convolutional/history_buffer.c
+++ b/core/libcorrect/src/convolutional/history_buffer.c
@@ -45,7 +45,7 @@ uint8_t *history_buffer_get_slice(history_buffer *buf) { return buf->history[buf
 
 shift_register_t history_buffer_search(history_buffer *buf, const distance_t *distances,
                                        unsigned int search_every) {
-    shift_register_t bestpath;
+    shift_register_t bestpath = 0;
     distance_t leasterror = USHRT_MAX;
     // search for a state with the least error
     for (shift_register_t state = 0; state < buf->num_states; state += search_every) {


### PR DESCRIPTION
I understand that you're vendoring a copy of libcorrect (for whom I'm also submitting this), but given that they haven't committed since 2018, I figured I'd post it here, too. Eliminates a compiler warning by initializing to a somewhat dubious 0. I feel there ought be an actual error sentinel here, but no such luck with the unsigned type; at least return a known something.