### PR TITLE
Satisfy GCC -Wformat-security with string literals

### DIFF
--- a/core/src/gui/menus/module_manager.cpp
+++ b/core/src/gui/menus/module_manager.cpp
@@ -43,10 +43,10 @@ namespace module_manager_menu {
                 ImGui::TableNextRow();
 
                 ImGui::TableSetColumnIndex(0);
-                ImGui::Text("%s", name.c_str());
+                ImGui::TextUnformatted(name.c_str());
 
                 ImGui::TableSetColumnIndex(1);
-                ImGui::Text("%s", inst.module.info->name);
+                ImGui::TextUnformatted(inst.module.info->name);
 
                 ImGui::TableSetColumnIndex(2);
                 ImVec2 origPos = ImGui::GetCursorPos();
@@ -69,7 +69,7 @@ namespace module_manager_menu {
         }
 
         ImGui::GenericDialog("module_mgr_error_", errorOpen, GENERIC_DIALOG_BUTTONS_OK, []() {
-            ImGui::Text("%s", errorMessage.c_str());
+            ImGui::TextUnformatted(errorMessage.c_str());
         });
 
         // Add module row with slightly different settings

--- a/core/src/gui/menus/module_manager.cpp
+++ b/core/src/gui/menus/module_manager.cpp
@@ -43,10 +43,10 @@ namespace module_manager_menu {
                 ImGui::TableNextRow();
 
                 ImGui::TableSetColumnIndex(0);
-                ImGui::Text(name.c_str());
+                ImGui::Text("%s", name.c_str());
 
                 ImGui::TableSetColumnIndex(1);
-                ImGui::Text(inst.module.info->name);
+                ImGui::Text("%s", inst.module.info->name);
 
                 ImGui::TableSetColumnIndex(2);
                 ImVec2 origPos = ImGui::GetCursorPos();
@@ -69,7 +69,7 @@ namespace module_manager_menu {
         }
 
         ImGui::GenericDialog("module_mgr_error_", errorOpen, GENERIC_DIALOG_BUTTONS_OK, []() {
-            ImGui::Text(errorMessage.c_str());
+            ImGui::Text("%s", errorMessage.c_str());
         });
 
         // Add module row with slightly different settings

--- a/core/src/gui/menus/vfo_color.cpp
+++ b/core/src/gui/menus/vfo_color.cpp
@@ -129,7 +129,7 @@ namespace vfo_color_menu {
                 core::configManager.release(true);
             }
             ImGui::SameLine();
-            ImGui::Text("%s", name.c_str());
+            ImGui::TextUnformatted(name.c_str());
         }
         ImGui::EndTable();
     }

--- a/core/src/gui/menus/vfo_color.cpp
+++ b/core/src/gui/menus/vfo_color.cpp
@@ -129,7 +129,7 @@ namespace vfo_color_menu {
                 core::configManager.release(true);
             }
             ImGui::SameLine();
-            ImGui::Text(name.c_str());
+            ImGui::Text("%s", name.c_str());
         }
         ImGui::EndTable();
     }

--- a/core/src/gui/style.cpp
+++ b/core/src/gui/style.cpp
@@ -49,7 +49,7 @@ namespace ImGui {
     void LeftLabel(const char* text) {
         float vpos = ImGui::GetCursorPosY();
         ImGui::SetCursorPosY(vpos + GImGui->Style.FramePadding.y);
-        ImGui::Text(text);
+        ImGui::Text("%s", text);
         ImGui::SameLine();
         ImGui::SetCursorPosY(vpos);
     }

--- a/core/src/gui/style.cpp
+++ b/core/src/gui/style.cpp
@@ -49,7 +49,7 @@ namespace ImGui {
     void LeftLabel(const char* text) {
         float vpos = ImGui::GetCursorPosY();
         ImGui::SetCursorPosY(vpos + GImGui->Style.FramePadding.y);
-        ImGui::Text("%s", text);
+        ImGui::TextUnformatted(text);
         ImGui::SameLine();
         ImGui::SetCursorPosY(vpos);
     }

--- a/core/src/gui/widgets/waterfall.cpp
+++ b/core/src/gui/widgets/waterfall.cpp
@@ -433,7 +433,7 @@ namespace ImGui {
                     char buf[128];
                     ImGui::BeginTooltip();
 
-                    ImGui::Text("%s", name.c_str());
+                    ImGui::TextUnformatted(name.c_str());
 
                     if (ImGui::IsKeyDown(GLFW_KEY_LEFT_CONTROL) || ImGui::IsKeyDown(GLFW_KEY_RIGHT_CONTROL)) {
                         ImGui::Separator();

--- a/core/src/gui/widgets/waterfall.cpp
+++ b/core/src/gui/widgets/waterfall.cpp
@@ -433,7 +433,7 @@ namespace ImGui {
                     char buf[128];
                     ImGui::BeginTooltip();
 
-                    ImGui::Text(name.c_str());
+                    ImGui::Text("%s", name.c_str());
 
                     if (ImGui::IsKeyDown(GLFW_KEY_LEFT_CONTROL) || ImGui::IsKeyDown(GLFW_KEY_RIGHT_CONTROL)) {
                         ImGui::Separator();

--- a/decoder_modules/m17_decoder/src/main.cpp
+++ b/decoder_modules/m17_decoder/src/main.cpp
@@ -193,19 +193,19 @@ private:
                 ImGui::TableSetColumnIndex(0);
                 ImGui::Text("Source");
                 ImGui::TableSetColumnIndex(1);
-                ImGui::Text("%s", _this->lsf.src.c_str());
+                ImGui::TextUnformatted(_this->lsf.src.c_str());
 
                 ImGui::TableNextRow();
                 ImGui::TableSetColumnIndex(0);
                 ImGui::Text("Destination");
                 ImGui::TableSetColumnIndex(1);
-                ImGui::Text("%s", _this->lsf.dst.c_str());
+                ImGui::TextUnformatted(_this->lsf.dst.c_str());
 
                 ImGui::TableNextRow();
                 ImGui::TableSetColumnIndex(0);
                 ImGui::Text("Data Type");
                 ImGui::TableSetColumnIndex(1);
-                ImGui::Text("%s", M17DataTypesTxt[_this->lsf.dataType]);
+                ImGui::TextUnformatted(M17DataTypesTxt[_this->lsf.dataType]);
 
                 ImGui::TableNextRow();
                 ImGui::TableSetColumnIndex(0);

--- a/decoder_modules/m17_decoder/src/main.cpp
+++ b/decoder_modules/m17_decoder/src/main.cpp
@@ -193,19 +193,19 @@ private:
                 ImGui::TableSetColumnIndex(0);
                 ImGui::Text("Source");
                 ImGui::TableSetColumnIndex(1);
-                ImGui::Text(_this->lsf.src.c_str());
+                ImGui::Text("%s", _this->lsf.src.c_str());
 
                 ImGui::TableNextRow();
                 ImGui::TableSetColumnIndex(0);
                 ImGui::Text("Destination");
                 ImGui::TableSetColumnIndex(1);
-                ImGui::Text(_this->lsf.dst.c_str());
+                ImGui::Text("%s", _this->lsf.dst.c_str());
 
                 ImGui::TableNextRow();
                 ImGui::TableSetColumnIndex(0);
                 ImGui::Text("Data Type");
                 ImGui::TableSetColumnIndex(1);
-                ImGui::Text(M17DataTypesTxt[_this->lsf.dataType]);
+                ImGui::Text("%s", M17DataTypesTxt[_this->lsf.dataType]);
 
                 ImGui::TableNextRow();
                 ImGui::TableSetColumnIndex(0);

--- a/misc_modules/frequency_manager/src/main.cpp
+++ b/misc_modules/frequency_manager/src/main.cpp
@@ -738,7 +738,7 @@ private:
         }
 
         ImGui::BeginTooltip();
-        ImGui::Text("%s", hoveredBookmarkName.c_str());
+        ImGui::TextUnformatted(hoveredBookmarkName.c_str());
         ImGui::Separator();
         ImGui::Text("List: %s", hoveredBookmark.listName.c_str());
         ImGui::Text("Frequency: %s", utils::formatFreq(hoveredBookmark.bookmark.frequency).c_str());

--- a/misc_modules/frequency_manager/src/main.cpp
+++ b/misc_modules/frequency_manager/src/main.cpp
@@ -738,7 +738,7 @@ private:
         }
 
         ImGui::BeginTooltip();
-        ImGui::Text(hoveredBookmarkName.c_str());
+        ImGui::Text("%s", hoveredBookmarkName.c_str());
         ImGui::Separator();
         ImGui::Text("List: %s", hoveredBookmark.listName.c_str());
         ImGui::Text("Frequency: %s", utils::formatFreq(hoveredBookmark.bookmark.frequency).c_str());


### PR DESCRIPTION
GCC 11.1 fails to build the application without this change, emitting "format not a string literal and no format arguments [-Wformat-security]".