### PR TITLE
Fix spelling errors

### DIFF
--- a/core/src/core.cpp
+++ b/core/src/core.cpp
@@ -311,7 +311,7 @@ int sdrpp_main(int argc, char* argv[]) {
     json bandColors = core::configManager.conf["bandColors"];
     core::configManager.release();
 
-    // Assert that the resource directory is absolute and check existance
+    // Assert that the resource directory is absolute and check existence
     resDir = std::filesystem::absolute(resDir).string();
     if (!std::filesystem::is_directory(resDir)) {
         spdlog::error("Resource directory doesn't exist! Please make sure that you've configured it correctly in config.json (check readme for details)");

--- a/core/src/dsp/compression.h
+++ b/core/src/dsp/compression.h
@@ -72,7 +72,7 @@ namespace dsp {
             float maxVal = ((float*)_in->readBuf)[maxIdx];
             *scaler = maxVal;
 
-            // Convert to the right type and send it out (sign bit determins pcm type)
+            // Convert to the right type and send it out (sign bit determines pcm type)
             if (type == PCM_TYPE_I8) {
                 volk_32f_s32f_convert_8i((int8_t*)dataBuf, (float*)_in->readBuf, 128.0f / maxVal, count * 2);
                 _in->flush();

--- a/core/src/gui/widgets/line_push_image.cpp
+++ b/core/src/gui/widgets/line_push_image.cpp
@@ -46,7 +46,7 @@ namespace ImGui {
         int oldLineCount = _lineCount;
         _lineCount += count;
 
-        // If new data either fills up or excedes the limit, reallocate
+        // If new data either fills up or exceeds the limit, reallocate
         // TODO: Change it to avoid bug if count >= reservedIncrement
         if (_lineCount > reservedCount) {
             printf("Reallocating\n");

--- a/core/src/utils/new_networking.h
+++ b/core/src/utils/new_networking.h
@@ -6,7 +6,7 @@
 #include <condition_variable>
 
 /*
-    Ryzerth's Epic Networking Functins
+    Ryzerth's Epic Networking Functions
 */
 
 namespace net {

--- a/decoder_modules/radio/src/radio_module.h
+++ b/decoder_modules/radio/src/radio_module.h
@@ -34,7 +34,7 @@ public:
     RadioModule(std::string name) {
         this->name = name;
 
-        // Intialize option lists
+        // Initialize option lists
         deempModes.define("None", DEEMP_MODE_NONE);
         deempModes.define("22us", DEEMP_MODE_22US);
         deempModes.define("50us", DEEMP_MODE_50US);
@@ -456,7 +456,7 @@ private:
             setDeemphasisMode(deempModes[deempId]);
         }
         else {
-            // Disable everyting if post processing is disabled
+            // Disable everything if post processing is disabled
             afChain.disableAll();
         }
 

--- a/source_modules/airspy_source/src/main.cpp
+++ b/source_modules/airspy_source/src/main.cpp
@@ -444,7 +444,7 @@ private:
             }
         }
         else if (_this->gainMode == 2) {
-            // TODO: Switch to a table for alignement
+            // TODO: Switch to a table for alignment
             if (_this->lnaAgc) { SmGui::BeginDisabled(); }
             SmGui::LeftLabel("LNA Gain");
             SmGui::FillWidth();


### PR DESCRIPTION
This PR fixes some spelling errors in comments, ignoring some words and skipping the directories that contain code not maintained in this repository.

None of the words changed are visible in the user interface, however fixing them with this PR and adding the `codespell` invocation to a continuous integration pipeline will allow to spot immediately any error that may have a bigger impact, because `codespell` exits with a non-zero return code when it finds an error.

Fixed with:
`codespell --ignore-words-list=hist,parm,sur --skip=./core/src/imgui,./core/src/spdlog,./misc_modules/discord_integration/discord-rpc,./misc_modules/discord_integration/discord-rpc/include/rapidjson --interactive=2 --write-changes`

I'm ignoring the word `parm` because it's an abbreviation that I used sometimes:
```
misc_modules/rigctl_server/src/main.cpp:688:                /* Bit field list of get parm */
misc_modules/rigctl_server/src/main.cpp:690:                /* Bit field list of set parm */
```
