### PR TITLE
Avoid an audio_sink Crash and Provide RtAudio Bug Workaround

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -388,6 +388,15 @@ If you also have the SoapySDR module loaded (not necessarily enabled), this is a
 The solution until a fixed libhackrf version is released is to completely remove the soapy_source module from SDR++. To do this, delete `modules/soapy_source.dll` on windows
 or `/usr/lib/sdrpp/plugins/soapy_source.so` on linux.
 
+## SDR++ doesn't show my devices (Linux)
+
+If you're running a recent Linux distribution that is using PipeWire instead of PulseAudio and you're using the enabled by default audio_sink you may be running accross a bug in the RtAudio library.
+Try running sdrpp with PIPEWIRE_PROPS and the jack-filter-name option set so that the PipeWire jack implementation removes certain characters from audio device names and avoids that bug.
+
+For example: `PIPEWIRE_PROPS='{ jack.filter-name=true }' ./build/sdrpp -r root_dev`
+
+If you are actually using jack/jack2 you will need to rename any devices/ports that have regex characters in the name.
+
 ## Issue not listed here?
 
 If you still have an issue, please open an issue about it or ask on the discord. I'll try to respond as quickly as I can. Please avoid trying to contact me on every platform imaginable thinking I'll respond faster though...

--- a/sdrpp.desktop
+++ b/sdrpp.desktop
@@ -3,7 +3,8 @@ Encoding=UTF-8
 Version=1.0
 Type=Application
 Terminal=false
-Exec=@CMAKE_INSTALL_PREFIX@/bin/sdrpp
+# PipeWire props is set to minimize the chance of hitting an RtAudio bug
+Exec=env PIPEWIRE_PROPS='{ jack.filter-name=true }' @CMAKE_INSTALL_PREFIX@/bin/sdrpp
 Name=SDR++
 Icon=@CMAKE_INSTALL_PREFIX@/share/sdrpp/icons/sdrpp.png
 Categories=HamRadio

--- a/sink_modules/audio_sink/src/main.cpp
+++ b/sink_modules/audio_sink/src/main.cpp
@@ -186,8 +186,12 @@ private:
         stereoPacker.stop();
         monoPacker.out.stopReader();
         stereoPacker.out.stopReader();
-        audio.stopStream();
-        audio.closeStream();
+        try {
+            audio.stopStream();
+            audio.closeStream();
+        } catch (RtAudioError& e) {
+            spdlog::error("Could not close audio device - maybe it failed to open?");
+        }
         monoPacker.out.clearReadStop();
         stereoPacker.out.clearReadStop();
     }


### PR DESCRIPTION
I can see you're working on possible replacements for the current audio_sink so I haven't properly reworked the logic around doStart() and AudioSink::running. Happy to do that if you would prefer. This bug does result in SDR++ crashing on startup from the get go on one of my machines, and on the other once I select a device that won't be able to be opened SDR++ crashes every time until I manually adjust audio_sink_config.json

I've also documented an RtAudio bug that causes issues on a default fresh install of Fedora 35 and will likely cause issues on other Linux distributions (like RedHat 8+). I'm going to look at submitting a patch to RtAudio for that. Happy to split that out of this PR or move it to the wiki or somewhere else if you don't want it here.

Thanks for the tool! I've only just started playing around with SDR and SDR++ is one of my favorite tools.