### PR TITLE
Allow user defined CMAKE_INSTALL_PREFIX

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,10 +1,12 @@
 cmake_minimum_required(VERSION 3.13)
 project(sdrpp)
 
-if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
-    set(CMAKE_INSTALL_PREFIX "/usr/local")
-else()
-    set(CMAKE_INSTALL_PREFIX "/usr")
+if (CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
+    if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+        set(CMAKE_INSTALL_PREFIX "/usr/local")
+    else()
+        set(CMAKE_INSTALL_PREFIX "/usr")
+    endif()
 endif()
 
 # Configure toolchain for android


### PR DESCRIPTION
Please allow to use user defined CMAKE_INSTALL_PREFIX when building. Makes things easier when having to deal with several different build environments on a single machine.