### PR TITLE
Move exponential zoom logic to WaterFall::setZoom

### DIFF
--- a/core/src/gui/main_window.cpp
+++ b/core/src/gui/main_window.cpp
@@ -620,6 +620,7 @@ void MainWindow::draw() {
     ImGui::TextUnformatted("Zoom");
     ImGui::SetCursorPosX((ImGui::GetWindowSize().x / 2.0) - 10 * style::uiScale);
     ImVec2 wfSliderSize(20.0 * style::uiScale, 150.0 * style::uiScale);
+    bw = gui::waterfall.getZoom(); // check if the zoom hasn't been updated
     if (ImGui::VSliderFloat("##_7_", wfSliderSize, &bw, 1.0, 0.0, "")) {
         gui::waterfall.setZoom(bw);
         if (vfo != NULL) {

--- a/core/src/gui/main_window.cpp
+++ b/core/src/gui/main_window.cpp
@@ -621,14 +621,7 @@ void MainWindow::draw() {
     ImGui::SetCursorPosX((ImGui::GetWindowSize().x / 2.0) - 10 * style::uiScale);
     ImVec2 wfSliderSize(20.0 * style::uiScale, 150.0 * style::uiScale);
     if (ImGui::VSliderFloat("##_7_", wfSliderSize, &bw, 1.0, 0.0, "")) {
-        double factor = (double)bw * (double)bw;
-
-        // Map 0.0 -> 1.0 to 1000.0 -> bandwidth
-        double wfBw = gui::waterfall.getBandwidth();
-        double delta = wfBw - 1000.0;
-        double finalBw = std::min<double>(1000.0 + (factor * delta), wfBw);
-
-        gui::waterfall.setViewBandwidth(finalBw);
+        gui::waterfall.setZoom(bw);
         if (vfo != NULL) {
             gui::waterfall.setViewOffset(vfo->centerOffset); // center vfo on screen
         }

--- a/core/src/gui/widgets/waterfall.cpp
+++ b/core/src/gui/widgets/waterfall.cpp
@@ -993,6 +993,17 @@ namespace ImGui {
         updateAllVFOs();
     }
 
+    void WaterFall::setZoom(double bw) {
+        double factor = bw * bw;
+
+        // Map 0.0 -> 1.0 to 1000.0 -> bandwidth
+        double wfBw = getBandwidth();
+        double delta = wfBw - 1000.0;
+        double finalBw = std::min<double>(1000.0 + (factor * delta), wfBw);
+
+        setViewBandwidth(finalBw);
+    }
+
     double WaterFall::getViewBandwidth() {
         return viewBandwidth;
     }

--- a/core/src/gui/widgets/waterfall.cpp
+++ b/core/src/gui/widgets/waterfall.cpp
@@ -81,6 +81,7 @@ namespace ImGui {
         waterfallFb = new uint32_t[1];
 
         viewBandwidth = 1.0;
+        viewZoom = 1.0;
         wholeBandwidth = 1.0;
 
         updatePallette(DEFAULT_COLOR_MAP, 13);
@@ -986,6 +987,7 @@ namespace ImGui {
             }
         }
         viewBandwidth = bandWidth;
+        viewZoom = calculateZoomLevelFromBw(bandWidth);
         lowerFreq = (centerFreq + viewOffset) - (viewBandwidth / 2.0);
         upperFreq = (centerFreq + viewOffset) + (viewBandwidth / 2.0);
         range = findBestRange(bandWidth, maxHSteps);
@@ -993,8 +995,9 @@ namespace ImGui {
         updateAllVFOs();
     }
 
-    void WaterFall::setZoom(double bw) {
-        double factor = bw * bw;
+    void WaterFall::setZoom(double zoomLevel) {
+        viewZoom = zoomLevel;
+        double factor = zoomLevel * zoomLevel;
 
         // Map 0.0 -> 1.0 to 1000.0 -> bandwidth
         double wfBw = getBandwidth();
@@ -1002,6 +1005,17 @@ namespace ImGui {
         double finalBw = std::min<double>(1000.0 + (factor * delta), wfBw);
 
         setViewBandwidth(finalBw);
+    }
+
+    double WaterFall::getZoom() {
+        return viewZoom;
+    }
+
+    double WaterFall::calculateZoomLevelFromBw(double bw) {
+        double wfBw = getBandwidth();
+        double onCurve = (bw - 1000.0) / (wfBw - 1000.0);
+        double zoomLevel = std::sqrt(onCurve);
+        return zoomLevel;
     }
 
     double WaterFall::getViewBandwidth() {

--- a/core/src/gui/widgets/waterfall.h
+++ b/core/src/gui/widgets/waterfall.h
@@ -153,6 +153,8 @@ namespace ImGui {
         float getWaterfallMax();
 
         void setZoom(double zoomLevel);
+        double getZoom();
+
         void setOffset(double zoomOffset);
 
         void autoRange();
@@ -258,6 +260,7 @@ namespace ImGui {
         void updateWaterfallTexture();
         void updateAllVFOs(bool checkRedrawRequired = false);
         bool calculateVFOSignalInfo(float* fftLine, WaterfallVFO* vfo, float& strength, float& snr);
+        double calculateZoomLevelFromBw(double bw);
 
         bool waterfallUpdate = false;
 
@@ -285,7 +288,8 @@ namespace ImGui {
         int fftHeight;           // Height of the fft graph
         int waterfallHeight = 0; // Height of the waterfall
 
-        double viewBandwidth;
+        double viewBandwidth; // actual bandwidth displayed
+        double viewZoom;      // linearized representation of the current zoom (e. g. percentage on a slider)
         double viewOffset;
 
         double lowerFreq;


### PR DESCRIPTION
WaterFall::setZoom is declared in [waterfall.h](https://github.com/AlexandreRouma/SDRPlusPlus/blob/80d244003ad143a78ef1bd1cfd4a07c385baa77c/core/src/gui/widgets/waterfall.h#L155), but wasn't implemented.

I'm doing this in preparation of another PR.