### PR TITLE
waterfall: right click to tune the strongest signal

### DIFF
--- a/core/src/gui/widgets/waterfall.cpp
+++ b/core/src/gui/widgets/waterfall.cpp
@@ -617,14 +617,10 @@ namespace ImGui {
         float* rawFFT = &rawFFTs[currentFFTLine * rawFFTSize];
 
         double wfAvg = 0.0;
-        double medWfAvg = 0.0;
         for (size_t i = 0; i < rawFFTSize; i++) {
             // iteratively calculate the mean of the FFT array
-            medWfAvg += ((double) rawFFT[i] - medWfAvg) / (i + 1);
-            wfAvg += (double) rawFFT[i];
+            wfAvg += ((double) rawFFT[i] - wfAvg) / (i + 1);
         }
-        wfAvg /= rawFFTSize;
-        spdlog::warn("mean: {}, avg: {}", medWfAvg, wfAvg);
 
         // first see what's around us (10 % of bw)
         int bigPeakIdx = calculateStrongestSignalIdx(posRel, 0.1);

--- a/core/src/gui/widgets/waterfall.h
+++ b/core/src/gui/widgets/waterfall.h
@@ -258,6 +258,8 @@ namespace ImGui {
         void updateWaterfallTexture();
         void updateAllVFOs(bool checkRedrawRequired = false);
         bool calculateVFOSignalInfo(float* fftLine, WaterfallVFO* vfo, float& strength, float& snr);
+        double calculateStrongestSignal(double posRel);
+        int calculateStrongestSignalPosX(double posRel, double rangeRel);
 
         bool waterfallUpdate = false;
 

--- a/core/src/gui/widgets/waterfall.h
+++ b/core/src/gui/widgets/waterfall.h
@@ -259,7 +259,7 @@ namespace ImGui {
         void updateAllVFOs(bool checkRedrawRequired = false);
         bool calculateVFOSignalInfo(float* fftLine, WaterfallVFO* vfo, float& strength, float& snr);
         double calculateStrongestSignal(double posRel);
-        int calculateStrongestSignalPosX(double posRel, double rangeRel);
+        size_t calculateStrongestSignalIdx(double posRel, double rangeRel);
 
         bool waterfallUpdate = false;
 


### PR DESCRIPTION
Right-clicking the waterfall tunes to the strongest displayed signal within 10 % of the waterfall where the user clicked. It uses FFT data from the waterfall display. Because of the limited resolution, it's not absolutely perfect (it's limited by resolution of FFT), but it's more than good enough. On 8 MHz bandwidth, I can comfortably listen to air band and click around without having to zoom in, adjust the VFO, zoom out to see the whole band...

I'm not sure if it should also snap according to the interval specified by the user, like with normal tuning using LMB.