### PR TITLE
Frequency manager quick jump

### DIFF
--- a/misc_modules/frequency_manager/src/main.cpp
+++ b/misc_modules/frequency_manager/src/main.cpp
@@ -401,8 +401,7 @@ private:
         FrequencyManagerModule* _this = (FrequencyManagerModule*)ctx;
         float menuWidth = ImGui::GetContentRegionAvail().x;
 
-        if(ImGui::IsKeyPressed(ImGuiKey_Space)&&ImGui::IsKeyDown(ImGuiKey_LeftCtrl))
-        {
+        if (ImGui::IsKeyPressed(ImGuiKey_Space) && ImGui::IsKeyPressed(ImGuiKey_ModCtrl)) {
             _this->quickJumpOpen = true;
         }
 

--- a/misc_modules/frequency_manager/src/main.cpp
+++ b/misc_modules/frequency_manager/src/main.cpp
@@ -401,7 +401,7 @@ private:
         FrequencyManagerModule* _this = (FrequencyManagerModule*)ctx;
         float menuWidth = ImGui::GetContentRegionAvail().x;
 
-        if (ImGui::IsKeyPressed(ImGuiKey_Space) && ImGui::IsKeyPressed(ImGuiKey_ModCtrl)) {
+        if (ImGui::IsKeyPressed(ImGuiKey_Q) && ImGui::IsKeyPressed(ImGuiKey_ModCtrl)) {
             _this->quickJumpOpen = true;
         }
 

--- a/misc_modules/frequency_manager/src/main.cpp
+++ b/misc_modules/frequency_manager/src/main.cpp
@@ -401,7 +401,7 @@ private:
         FrequencyManagerModule* _this = (FrequencyManagerModule*)ctx;
         float menuWidth = ImGui::GetContentRegionAvail().x;
 
-        if (ImGui::IsKeyPressed(ImGuiKey_Q) && ImGui::IsKeyPressed(ImGuiKey_ModCtrl)) {
+        if (ImGui::IsKeyPressed(ImGuiKey_F) && ImGui::IsKeyPressed(ImGuiKey_ModCtrl)) {
             _this->quickJumpOpen = true;
         }
 


### PR DESCRIPTION
This pull request adds a popup dialogue to let users quickly jump between bookmarks.
The popup is activated by pressing **Ctrl + Space**.
It displays all bookmarks in the current list, with a search filter at the top.
The search filter is not case sensitive.
When a bookmark is selected the bookmark's frequency is tuned.
The popup dialog remains in case the wrong selection was chosen.
The popup is then closed by pressing **Enter** or **Escape** or by clicking **ok** in the popup.
![image](https://user-images.githubusercontent.com/57029490/166089283-5a41f9a1-2fa9-4c96-813b-35d820e480dc.png)
