### PR TITLE
Add UI control for vsync

### DIFF
--- a/core/backends/android/backend.cpp
+++ b/core/backends/android/backend.cpp
@@ -158,7 +158,7 @@ namespace backend {
         ImGui::NewFrame();
     }
 
-    void render(bool vsync) {
+    void render() {
         // Rendering
         ImGui::Render();
         auto dSize = ImGui::GetIO().DisplaySize;
@@ -167,6 +167,7 @@ namespace backend {
         glClear(GL_COLOR_BUFFER_BIT);
         ImGui_ImplOpenGL3_RenderDrawData(ImGui::GetDrawData());
         eglSwapBuffers(_EglDisplay, _EglSurface);
+        // TODO: add support for v-sync on Android
     }
 
     // No screen pos to detect

--- a/core/backends/glfw/backend.cpp
+++ b/core/backends/glfw/backend.cpp
@@ -39,6 +39,7 @@ namespace backend {
 
     #define OPENGL_VERSION_COUNT (sizeof(OPENGL_VERSIONS_GLSL) / sizeof(char*))
 
+    bool vsync;
     bool maximized = false;
     bool fullScreen = false;
     int winHeight;
@@ -69,6 +70,7 @@ namespace backend {
         winHeight = core::configManager.conf["windowSize"]["h"];
         maximized = core::configManager.conf["maximized"];
         fullScreen = core::configManager.conf["fullscreen"];
+        vsync = core::configManager.conf["vsync"];
         core::configManager.release();
 
         // Setup window
@@ -205,7 +207,7 @@ namespace backend {
         ImGui::NewFrame();
     }
 
-    void render(bool vsync) {
+    void render() {
         // Rendering
         ImGui::Render();
         int display_w, display_h;

--- a/core/src/backend.h
+++ b/core/src/backend.h
@@ -4,7 +4,7 @@
 namespace backend {
     int init(std::string resDir = "");
     void beginFrame();
-    void render(bool vsync = true);
+    void render();
     void getMouseScreenPos(double& x, double& y);
     void setMouseScreenPos(double x, double y);
     int renderLoop();

--- a/core/src/core.cpp
+++ b/core/src/core.cpp
@@ -123,6 +123,7 @@ int sdrpp_main(int argc, char* argv[]) {
     defConfig["max"] = 0.0;
     defConfig["maximized"] = false;
     defConfig["fullscreen"] = false;
+    defConfig["vsync"] = true;
 
     // Menu
     defConfig["menuElements"] = json::array();

--- a/core/src/gui/dialogs/loading_screen.cpp
+++ b/core/src/gui/dialogs/loading_screen.cpp
@@ -42,6 +42,6 @@ namespace LoadingScreen {
 
         ImGui::End();
 
-        backend::render(false);
+        backend::render();
     }
 }

--- a/core/src/gui/menus/display.cpp
+++ b/core/src/gui/menus/display.cpp
@@ -13,6 +13,7 @@ namespace displaymenu {
     bool showWaterfall;
     bool fastFFT = true;
     bool fullWaterfallUpdate = true;
+    bool vsync;
     int colorMapId = 0;
     std::vector<std::string> colorMapNames;
     std::string colorMapNamesTxt = "";
@@ -86,6 +87,8 @@ namespace displaymenu {
 
         fullWaterfallUpdate = core::configManager.conf["fullWaterfallUpdate"];
         gui::waterfall.setFullWaterfallUpdate(fullWaterfallUpdate);
+
+        vsync = core::configManager.conf["vsync"];
 
         fftSizeId = 3;
         int fftSize = core::configManager.conf["fftSize"];
@@ -173,6 +176,16 @@ namespace displaymenu {
             core::configManager.release(true);
             restartRequired = true;
         }
+
+#ifndef __ANDROID__
+        // TODO: add support for v-sync on Android
+        if (ImGui::Checkbox("V-Sync##_sdrpp", &vsync)) {
+            core::configManager.acquire();
+            core::configManager.conf["vsync"] = vsync;
+            core::configManager.release(true);
+            restartRequired = true;
+        }
+#endif
 
         ImGui::LeftLabel("FFT Framerate");
         ImGui::SetNextItemWidth(menuWidth - ImGui::GetCursorPosX());


### PR DESCRIPTION
On macOS, I have been experiencing some stuttering in the UI. This often happened when dragging the window or every few seconds while using SDR++, which would also cause the sound to stutter.

After debugging for a bit, it turned out it was due to vsync being enabled.

This adds an option in the UI for controlling vsync, as well as a setting on `config.json`. The setting defaults to enabled, so we keep the same default behavior as before (vsync enabled).

For now, there is no support for Android, as I don't have a device to test with - so this option is hidden on those builds.