### PR TITLE
Target macOS 10.15 when building

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,7 @@ project(sdrpp)
 
 if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
     set(CMAKE_INSTALL_PREFIX "/usr/local")
+    set(CMAKE_OSX_DEPLOYMENT_TARGET "10.15")
 else()
     set(CMAKE_INSTALL_PREFIX "/usr")
 endif()


### PR DESCRIPTION
SDR++ relies on `std::filesystem` which is only available when targeting macOS 10.15 and above (which is what the CI is using).

SDR++ wouldn't build on 12.1 unless I specified this.