### PR TITLE
Fix rtaudioerrortype compilation error

### DIFF
--- a/sink_modules/audio_sink/src/main.cpp
+++ b/sink_modules/audio_sink/src/main.cpp
@@ -172,7 +172,7 @@ private:
             audio.startStream();
             stereoPacker.start();
         }
-        catch (RtAudioError& e) {
+        catch (RtAudioErrorType& e) {
             spdlog::error("Could not open audio device");
             return;
         }


### PR DESCRIPTION
On compiling the code with latest rtaudio on Ubuntu 22.04 LTS, this error appears:

```
[ 83%] Building CXX object sink_modules/audio_sink/CMakeFiles/audio_sink.dir/src/main.cpp.o
/home/bjk/gnuradio/utils/SDRPlusPlus/sink_modules/audio_sink/src/main.cpp: In constructor ‘AudioSink::AudioSink(SinkManager::Stream*, std::string)’:
/home/bjk/gnuradio/utils/SDRPlusPlus/sink_modules/audio_sink/src/main.cpp:49:23: error: ‘struct RtAudio::DeviceInfo’ has no member named ‘probed’
   49 |             if (!info.probed) { continue; }
      |                       ^~~~~~
/home/bjk/gnuradio/utils/SDRPlusPlus/sink_modules/audio_sink/src/main.cpp: In member function ‘void AudioSink::doStart()’:
/home/bjk/gnuradio/utils/SDRPlusPlus/sink_modules/audio_sink/src/main.cpp:175:16: error: ‘RtAudioError’ does not name a type; did you mean ‘RtAudioErrorType’?
  175 |         catch (RtAudioError& e) {
      |                ^~~~~~~~~~~~
      |                RtAudioErrorType

```

This PR will fix this compiling error.