### PR TITLE
Optimize WaterFall::doZoom and fix imprecise zooming

### DIFF
--- a/core/src/gui/widgets/waterfall.h
+++ b/core/src/gui/widgets/waterfall.h
@@ -101,7 +101,6 @@ namespace ImGui {
 
             float* bufEnd = data + rawFFTSize;
             double factor = (double)width / (double)outWidth; // The output "FFT" is `factor` times smaller than the input.
-            double sFactor = ceil(factor);
             double id = offset;
             for (int i = 0; i < outWidth; i++) {
                 // For each pixel on the output, "window" the source FFT datapoints (starting from `&data[(int) id]`
@@ -109,13 +108,12 @@ namespace ImGui {
                 // The fractional part is discarded in the cast, so with zoomed-in view (`factor` < 1), pixels are "stretched".
                 // So with `factor` == 0.5, one pixel is `data[(int) 69]`, and the very next one is `data[(int) 69.5]`.
                 float* cursor = data + (int)id;
-                float* searchEnd = cursor + (int)sFactor;
-                
+                float* searchEnd = cursor + (int)factor;
                 if (searchEnd > bufEnd) { // This compiles into `cmp` and `cmovbe`, non-branching instructions.
                     searchEnd = bufEnd;
                 }
 
-                float maxVal = -INFINITY;
+                float maxVal = *cursor;
                 while (cursor != searchEnd) {
                     if (*cursor > maxVal) { maxVal = *cursor; }
                     cursor++;

--- a/core/src/gui/widgets/waterfall.h
+++ b/core/src/gui/widgets/waterfall.h
@@ -99,18 +99,20 @@ namespace ImGui {
                 width = 524288;
             }
 
-            float factor = (float)width / (float)outWidth;
-            float sFactor = ceilf(factor);
-            float uFactor;
-            float id = offset;
-            float maxVal;
-            int sId;
+            float* bufEnd = data + rawFFTSize;
+            double factor = (double)width / (double)outWidth;
+            double sFactor = ceil(factor);
+            double id = offset;
             for (int i = 0; i < outWidth; i++) {
-                maxVal = -INFINITY;
-                sId = (int)id;
-                uFactor = (sId + sFactor > rawFFTSize) ? sFactor - ((sId + sFactor) - rawFFTSize) : sFactor;
-                for (int j = 0; j < uFactor; j++) {
-                    if (data[sId + j] > maxVal) { maxVal = data[sId + j]; }
+                float* cursor = data + (int)id;
+                float* searchEnd = cursor + (int)sFactor;
+                if (searchEnd > bufEnd) {
+                    searchEnd = bufEnd;
+                }
+                float maxVal = -INFINITY;
+                while (cursor != searchEnd) {
+                    if (*cursor > maxVal) { maxVal = *cursor; }
+                    cursor++;
                 }
                 out[i] = maxVal;
                 id += factor;
@@ -306,6 +308,7 @@ namespace ImGui {
         float* rawFFTs = NULL;
         float* latestFFT;
         float* latestFFTHold;
+        float* tempZoomFFT;
         int currentFFTLine = 0;
         int fftLines = 0;
 


### PR DESCRIPTION
The waterfall was jumping around when zooming, it made VFOs randomly (float imprecision) offset from signals displayed on the waterfall. I also optimized the `doZoom` inline method. Now it's roughly twice as fast.