### PR TITLE
Updated rpi-install.sh and read.md to use libvolk2-dev

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -40,8 +40,6 @@ sudo apt install libfftw3-dev libglfw3-dev libvolk2-dev libsoapysdr-dev libairsp
 sudo dpkg -i sdrpp_debian_amd64.deb
 ```
 
-If `libvolk2-dev` is not available, use `libvolk1-dev`.
-
 ### Arch-based
 
 Install the latest release from the [sdrpp-git](https://aur.archlinux.org/packages/sdrpp-git/) AUR package

--- a/rpi_install.sh
+++ b/rpi_install.sh
@@ -5,7 +5,7 @@ set -e
 
 echo "Installing dependencies"
 sudo apt update
-sudo apt install -y build-essential cmake git libfftw3-dev libglfw3-dev libvolk1-dev libzstd-dev libsoapysdr-dev libairspyhf-dev libairspy-dev \
+sudo apt install -y build-essential cmake git libfftw3-dev libglfw3-dev libvolk2-dev libzstd-dev libsoapysdr-dev libairspyhf-dev libairspy-dev \
             libiio-dev libad9361-dev librtaudio-dev libhackrf-dev librtlsdr-dev libbladerf-dev liblimesuite-dev p7zip-full wget
 
 echo "Preparing build"


### PR DESCRIPTION
Tested to run the shell script on a raspberry pi 3b+ and libvolk1-dev did not seem to work. Switched to libvolk2-dev and it did build!