### PR TITLE
Correct USA amateur allocations below 2GHz

### DIFF
--- a/root/res/bandplans/usa.json
+++ b/root/res/bandplans/usa.json
@@ -6,6 +6,18 @@
     "author_url": "http://jkimsey.tech",
     "bands": [
         {
+            "name": "2200m Band",
+            "type": "amateur",
+            "start": 135700,
+            "end": 137800
+        },
+        {
+            "name": "630m Band",
+            "type": "amateur",
+            "start": 472000,
+            "end": 479000
+        },
+        {
             "name": "Long Wave",
             "type": "broadcast",
             "start": 148500,
@@ -39,12 +51,6 @@
             "name": "80m Ham Band",
             "type": "amateur",
             "start": 3500000,
-            "end": 3950000
-        },
-        {
-            "name": "Shortwave Broadcast",
-            "type": "broadcast",
-            "start": 3950000,
             "end": 4000000
         },
         {
@@ -60,10 +66,34 @@
             "end": 5060000
         },
         {
-            "name": "60m Ham Band",
+            "name": "60m Channel 1",
             "type": "amateur",
-            "start": 5351500,
-            "end": 5366500
+            "start": 5330500,
+            "end": 5333500
+        },
+        {
+            "name": "60m Channel 2",
+            "type": "amateur",
+            "start": 5346500,
+            "end": 5349500
+        },
+        {
+            "name": "60m Channel 3",
+            "type": "amateur",
+            "start": 5357000,
+            "end": 5360000
+        },
+        {
+            "name": "60m Channel 4",
+            "type": "amateur",
+            "start": 5371500,
+            "end": 5374500
+        },
+        {
+            "name": "60m Channel 5",
+            "type": "amateur",
+            "start": 5403500,
+            "end": 5406500
         },
         {
             "name": "Shortwave Broadcast",
@@ -75,12 +105,12 @@
             "name": "40m Ham Band",
             "type": "amateur",
             "start": 7000000,
-            "end": 7200000
+            "end": 7300000
         },
         {
             "name": "Shortwave Broadcast",
             "type": "broadcast",
-            "start": 7200000,
+            "start": 7300000,
             "end": 7450000
         },
         {
@@ -171,7 +201,7 @@
             "name": "10m Ham Band",
             "type": "amateur",
             "start": 28000000,
-            "end": 29750000
+            "end": 29700000
         },
         {
             "name": "6m Ham Band",
@@ -240,7 +270,13 @@
             "end": 216000000
         },
         {
-            "name": "1.25m Ham Band",
+            "name": "1.25m Band (lower)",
+            "type": "amateur",
+            "start": 219000000,
+            "end": 220000000
+        },
+        {
+            "name": "1.25m Band (upper)",
             "type": "amateur",
             "start": 222000000,
             "end": 225000000

--- a/root/res/bandplans/usa.json
+++ b/root/res/bandplans/usa.json
@@ -66,33 +66,9 @@
             "end": 5060000
         },
         {
-            "name": "60m Channel 1",
+            "name": "60m Ham Band",
             "type": "amateur",
             "start": 5330500,
-            "end": 5333500
-        },
-        {
-            "name": "60m Channel 2",
-            "type": "amateur",
-            "start": 5346500,
-            "end": 5349500
-        },
-        {
-            "name": "60m Channel 3",
-            "type": "amateur",
-            "start": 5357000,
-            "end": 5360000
-        },
-        {
-            "name": "60m Channel 4",
-            "type": "amateur",
-            "start": 5371500,
-            "end": 5374500
-        },
-        {
-            "name": "60m Channel 5",
-            "type": "amateur",
-            "start": 5403500,
             "end": 5406500
         },
         {


### PR DESCRIPTION
 - add 2200m band
 - add 630m band
 - fix 80m band - in US, it's 3.5-4.0 MHz
 - 60m band is 5 discrete "channels"
 - 40m band in US is 7.0-7.3 MHz
 - 10m band in US is 28.0-29.7 MHz
 - 1.25m band is in two parts; 219-220MHz and 222-225 MHz

Source: ARRL, FCC