### PR TITLE
Improvements for Debian builds

### DIFF
--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -143,13 +143,13 @@ jobs:
 
         - name: Recover Deb Archive
           working-directory: ${{runner.workspace}}
-          run: docker cp build:/root/SDRPlusPlus/sdrpp_debian_amd64.deb ./
+          run: docker cp build:/root/SDRPlusPlus/sdrpp_buster_amd64.deb ./
 
         - name: Save Deb Archive
           uses: actions/upload-artifact@v3
           with:
               name: sdrpp_debian_buster_amd64
-              path: ${{runner.workspace}}/sdrpp_debian_amd64.deb
+              path: ${{runner.workspace}}/sdrpp_buster_amd64.deb
 
     build_debian_bullseye:
         runs-on: ubuntu-latest
@@ -165,13 +165,13 @@ jobs:
 
         - name: Recover Deb Archive
           working-directory: ${{runner.workspace}}
-          run: docker cp build:/root/SDRPlusPlus/sdrpp_debian_amd64.deb ./
+          run: docker cp build:/root/SDRPlusPlus/sdrpp_bullseye_amd64.deb ./
 
         - name: Save Deb Archive
           uses: actions/upload-artifact@v3
           with:
               name: sdrpp_debian_bullseye_amd64
-              path: ${{runner.workspace}}/sdrpp_debian_amd64.deb
+              path: ${{runner.workspace}}/sdrpp_bullseye_amd64.deb
 
     build_debian_sid:
         runs-on: ubuntu-latest
@@ -187,13 +187,13 @@ jobs:
 
         - name: Recover Deb Archive
           working-directory: ${{runner.workspace}}
-          run: docker cp build:/root/SDRPlusPlus/sdrpp_debian_amd64.deb ./
+          run: docker cp build:/root/SDRPlusPlus/sdrpp_bookworm_amd64.deb ./
 
         - name: Save Deb Archive
           uses: actions/upload-artifact@v3
           with:
               name: sdrpp_debian_sid_amd64
-              path: ${{runner.workspace}}/sdrpp_debian_amd64.deb
+              path: ${{runner.workspace}}/sdrpp_bookworm_amd64.deb
 
     # build_ubuntu_bionic:
     #     runs-on: ubuntu-latest
@@ -231,13 +231,13 @@ jobs:
 
         - name: Recover Deb Archive
           working-directory: ${{runner.workspace}}
-          run: docker cp build:/root/SDRPlusPlus/sdrpp_debian_amd64.deb ./
+          run: docker cp build:/root/SDRPlusPlus/sdrpp_focal_amd64.deb ./
 
         - name: Save Deb Archive
           uses: actions/upload-artifact@v3
           with:
               name: sdrpp_ubuntu_focal_amd64
-              path: ${{runner.workspace}}/sdrpp_debian_amd64.deb
+              path: ${{runner.workspace}}/sdrpp_focal_amd64.deb
 
     build_ubuntu_jammy:
         runs-on: ubuntu-latest
@@ -253,13 +253,13 @@ jobs:
 
         - name: Recover Deb Archive
           working-directory: ${{runner.workspace}}
-          run: docker cp build:/root/SDRPlusPlus/sdrpp_debian_amd64.deb ./
+          run: docker cp build:/root/SDRPlusPlus/sdrpp_jammy_amd64.deb ./
 
         - name: Save Deb Archive
           uses: actions/upload-artifact@v3
           with:
               name: sdrpp_ubuntu_jammy_amd64
-              path: ${{runner.workspace}}/sdrpp_debian_amd64.deb
+              path: ${{runner.workspace}}/sdrpp_jammy_amd64.deb
 
     build_raspios_bullseye_armhf:
         runs-on: ARM
@@ -280,13 +280,13 @@ jobs:
 
         - name: Create Dev Archive
           working-directory: ${{runner.workspace}}
-          run: sh $GITHUB_WORKSPACE/make_debian_package.sh ./build 'libfftw3-dev, libglfw3-dev, libvolk2-dev, librtaudio-dev' && mv sdrpp_debian_amd64.deb sdrpp_debian_armhf.deb
+          run: sh $GITHUB_WORKSPACE/make_debian_package.sh ./build 'libfftw3-3, libglfw3, libvolk2.4, librtaudio6, libzstd1'
         
         - name: Save Deb Archive
           uses: actions/upload-artifact@v3
           with:
               name: sdrpp_raspios_bullseye_armhf
-              path: ${{runner.workspace}}/sdrpp_debian_armhf.deb
+              path: ${{runner.workspace}}/sdrpp_bullseye_armhf.deb
 
     build_android:
         runs-on: ubuntu-latest
@@ -328,12 +328,12 @@ jobs:
             mkdir sdrpp_all && 
             mv sdrpp_windows_x64/sdrpp_windows_x64.zip sdrpp_all/ && 
             mv sdrpp_macos_intel/sdrpp_macos_intel.zip sdrpp_all/ && 
-            mv sdrpp_debian_buster_amd64/sdrpp_debian_amd64.deb sdrpp_all/sdrpp_debian_buster_amd64.deb && 
-            mv sdrpp_debian_bullseye_amd64/sdrpp_debian_amd64.deb sdrpp_all/sdrpp_debian_bullseye_amd64.deb && 
-            mv sdrpp_debian_sid_amd64/sdrpp_debian_amd64.deb sdrpp_all/sdrpp_debian_sid_amd64.deb && 
-            mv sdrpp_ubuntu_focal_amd64/sdrpp_debian_amd64.deb sdrpp_all/sdrpp_ubuntu_focal_amd64.deb &&
-            mv sdrpp_ubuntu_jammy_amd64/sdrpp_debian_amd64.deb sdrpp_all/sdrpp_ubuntu_jammy_amd64.deb &&
-            mv sdrpp_raspios_bullseye_armhf/sdrpp_debian_armhf.deb sdrpp_all/sdrpp_raspios_bullseye_armhf.deb &&
+            mv sdrpp_debian_buster_amd64/sdrpp_buster_amd64.deb sdrpp_all/ && 
+            mv sdrpp_debian_bullseye_amd64/sdrpp_bullseye_amd64.deb sdrpp_all/ && 
+            mv sdrpp_debian_sid_amd64/sdrpp_sid_amd64.deb sdrpp_all && 
+            mv sdrpp_ubuntu_focal_amd64/sdrpp_focal_amd64.deb sdrpp_all/ &&
+            mv sdrpp_ubuntu_jammy_amd64/sdrpp_jammy_amd64.deb sdrpp_all/ &&
+            mv sdrpp_raspios_bullseye_armhf/sdrpp_bullseye_armhf.deb sdrpp_all/ &&
             mv sdrpp_android/sdrpp.apk sdrpp_all/sdrpp.apk
 
         - uses: actions/upload-artifact@v3

--- a/docker_builds/debian_bullseye/do_build.sh
+++ b/docker_builds/debian_bullseye/do_build.sh
@@ -1,10 +1,10 @@
-#!/bin/bash
+#!/bin/sh
 set -e
 cd /root
 
 # Install dependencies and tools
-apt update
-apt install -y build-essential cmake git lsb-release libfftw3-dev libglfw3-dev libvolk2-dev libzstd-dev libsoapysdr-dev libairspyhf-dev libairspy-dev \
+apt-get update
+apt-get install -y build-essential cmake git lsb-release libfftw3-dev libglfw3-dev libvolk2-dev libzstd-dev libsoapysdr-dev libairspyhf-dev libairspy-dev \
             libiio-dev libad9361-dev librtaudio-dev libhackrf-dev librtlsdr-dev libbladerf-dev liblimesuite-dev p7zip-full wget portaudio19-dev \
             libcodec2-dev
 
@@ -19,7 +19,7 @@ cd SDRPlusPlus
 mkdir build
 cd build
 cmake .. -DOPT_BUILD_BLADERF_SOURCE=ON -DOPT_BUILD_LIMESDR_SOURCE=ON -DOPT_BUILD_SDRPLAY_SOURCE=ON -DOPT_BUILD_NEW_PORTAUDIO_SINK=ON -DOPT_BUILD_M17_DECODER=ON
-make VERBOSE=1 -j2
+make VERBOSE=1 -j$(nproc)
 
 cd ..
-sh make_debian_package.sh ./build 'libfftw3-dev, libglfw3-dev, libvolk2-dev, librtaudio-dev, libzstd-dev'
+sh make_debian_package.sh ./build 'libfftw3-3, libglfw3, libvolk2.4, librtaudio6, libzstd1'

--- a/docker_builds/debian_bullseye/do_build.sh
+++ b/docker_builds/debian_bullseye/do_build.sh
@@ -4,7 +4,7 @@ cd /root
 
 # Install dependencies and tools
 apt update
-apt install -y build-essential cmake git libfftw3-dev libglfw3-dev libvolk2-dev libzstd-dev libsoapysdr-dev libairspyhf-dev libairspy-dev \
+apt install -y build-essential cmake git lsb-release libfftw3-dev libglfw3-dev libvolk2-dev libzstd-dev libsoapysdr-dev libairspyhf-dev libairspy-dev \
             libiio-dev libad9361-dev librtaudio-dev libhackrf-dev librtlsdr-dev libbladerf-dev liblimesuite-dev p7zip-full wget portaudio19-dev \
             libcodec2-dev
 

--- a/docker_builds/debian_buster/do_build.sh
+++ b/docker_builds/debian_buster/do_build.sh
@@ -3,8 +3,8 @@ set -e
 cd /root
 
 # Install dependencies and tools
-apt update
-apt install -y build-essential cmake git lsb-release libfftw3-dev libglfw3-dev libvolk1-dev libzstd-dev libsoapysdr-dev libairspyhf-dev libairspy-dev \
+apt-get update
+apt-get install -y build-essential cmake git lsb-release libfftw3-dev libglfw3-dev libvolk1-dev libzstd-dev libsoapysdr-dev libairspyhf-dev libairspy-dev \
             libiio-dev libad9361-dev librtaudio-dev libhackrf-dev librtlsdr-dev libbladerf-dev liblimesuite-dev p7zip-full wget portaudio19-dev \
             libcodec2-dev
 
@@ -19,7 +19,7 @@ cd SDRPlusPlus
 mkdir build
 cd build
 cmake .. -DOPT_BUILD_SDRPLAY_SOURCE=ON -DOPT_BUILD_BLADERF_SOURCE=OFF -DOPT_BUILD_LIMESDR_SOURCE=ON -DOPT_BUILD_NEW_PORTAUDIO_SINK=ON -DOPT_BUILD_M17_DECODER=ON
-make VERBOSE=1 -j2
+make VERBOSE=1 -j$(nproc)
 
 cd ..
-sh make_debian_package.sh ./build 'libfftw3-dev, libglfw3-dev, libvolk1-dev, librtaudio-dev, libzstd-dev'
+sh make_debian_package.sh ./build 'libfftw3-3, libglfw3, libvolk1.4, librtaudio6, libzstd1'

--- a/docker_builds/debian_buster/do_build.sh
+++ b/docker_builds/debian_buster/do_build.sh
@@ -22,4 +22,4 @@ cmake .. -DOPT_BUILD_SDRPLAY_SOURCE=ON -DOPT_BUILD_BLADERF_SOURCE=OFF -DOPT_BUIL
 make VERBOSE=1 -j$(nproc)
 
 cd ..
-sh make_debian_package.sh ./build 'libfftw3-3, libglfw3, libvolk1.4, librtaudio6, libzstd1'
+sh make_debian_package.sh ./build 'libfftw3-3, libglfw3, libopengl0, librtaudio6, libvolk1.4, libzstd1'

--- a/docker_builds/debian_buster/do_build.sh
+++ b/docker_builds/debian_buster/do_build.sh
@@ -4,7 +4,7 @@ cd /root
 
 # Install dependencies and tools
 apt update
-apt install -y build-essential cmake git libfftw3-dev libglfw3-dev libvolk1-dev libzstd-dev libsoapysdr-dev libairspyhf-dev libairspy-dev \
+apt install -y build-essential cmake git lsb-release libfftw3-dev libglfw3-dev libvolk1-dev libzstd-dev libsoapysdr-dev libairspyhf-dev libairspy-dev \
             libiio-dev libad9361-dev librtaudio-dev libhackrf-dev librtlsdr-dev libbladerf-dev liblimesuite-dev p7zip-full wget portaudio19-dev \
             libcodec2-dev
 

--- a/docker_builds/debian_sid/do_build.sh
+++ b/docker_builds/debian_sid/do_build.sh
@@ -4,7 +4,7 @@ cd /root
 
 # Install dependencies and tools
 apt update
-apt install -y build-essential cmake git libfftw3-dev libglfw3-dev libvolk2-dev libzstd-dev libsoapysdr-dev libairspyhf-dev libairspy-dev \
+apt install -y build-essential cmake git lsb-release libfftw3-dev libglfw3-dev libvolk2-dev libzstd-dev libsoapysdr-dev libairspyhf-dev libairspy-dev \
             libiio-dev libad9361-dev librtaudio-dev libhackrf-dev librtlsdr-dev libbladerf-dev liblimesuite-dev p7zip-full wget portaudio19-dev \
             libcodec2-dev
 

--- a/docker_builds/debian_sid/do_build.sh
+++ b/docker_builds/debian_sid/do_build.sh
@@ -3,8 +3,8 @@ set -e
 cd /root
 
 # Install dependencies and tools
-apt update
-apt install -y build-essential cmake git lsb-release libfftw3-dev libglfw3-dev libvolk2-dev libzstd-dev libsoapysdr-dev libairspyhf-dev libairspy-dev \
+apt-get update
+apt-get install -y build-essential cmake git lsb-release libfftw3-dev libglfw3-dev libvolk2-dev libzstd-dev libsoapysdr-dev libairspyhf-dev libairspy-dev \
             libiio-dev libad9361-dev librtaudio-dev libhackrf-dev librtlsdr-dev libbladerf-dev liblimesuite-dev p7zip-full wget portaudio19-dev \
             libcodec2-dev
 
@@ -19,7 +19,7 @@ cd SDRPlusPlus
 mkdir build
 cd build
 cmake .. -DOPT_BUILD_BLADERF_SOURCE=ON -DOPT_BUILD_LIMESDR_SOURCE=ON -DOPT_BUILD_SDRPLAY_SOURCE=ON -DOPT_BUILD_NEW_PORTAUDIO_SINK=ON -DOPT_BUILD_M17_DECODER=ON
-make VERBOSE=1 -j2
+make VERBOSE=1 -j$(nproc)
 
 cd ..
-sh make_debian_package.sh ./build 'libfftw3-dev, libglfw3-dev, libvolk2-dev, librtaudio-dev, libzstd-dev'
+sh make_debian_package.sh ./build 'libfftw3-3, libglfw3, libvolk2.5, librtaudio6, libzstd1'

--- a/docker_builds/ubuntu_focal/do_build.sh
+++ b/docker_builds/ubuntu_focal/do_build.sh
@@ -4,7 +4,7 @@ cd /root
 
 # Install dependencies and tools
 apt update
-apt install -y build-essential cmake git libfftw3-dev libglfw3-dev libvolk2-dev libzstd-dev libsoapysdr-dev libairspyhf-dev libairspy-dev \
+apt install -y build-essential cmake git lsb-release libfftw3-dev libglfw3-dev libvolk2-dev libzstd-dev libsoapysdr-dev libairspyhf-dev libairspy-dev \
             libiio-dev libad9361-dev librtaudio-dev libhackrf-dev librtlsdr-dev libbladerf-dev liblimesuite-dev p7zip-full wget portaudio19-dev \
             libcodec2-dev
 

--- a/docker_builds/ubuntu_focal/do_build.sh
+++ b/docker_builds/ubuntu_focal/do_build.sh
@@ -3,8 +3,8 @@ set -e
 cd /root
 
 # Install dependencies and tools
-apt update
-apt install -y build-essential cmake git lsb-release libfftw3-dev libglfw3-dev libvolk2-dev libzstd-dev libsoapysdr-dev libairspyhf-dev libairspy-dev \
+apt-get update
+apt-get install -y build-essential cmake git lsb-release libfftw3-dev libglfw3-dev libvolk2-dev libzstd-dev libsoapysdr-dev libairspyhf-dev libairspy-dev \
             libiio-dev libad9361-dev librtaudio-dev libhackrf-dev librtlsdr-dev libbladerf-dev liblimesuite-dev p7zip-full wget portaudio19-dev \
             libcodec2-dev
 
@@ -19,7 +19,7 @@ cd SDRPlusPlus
 mkdir build
 cd build
 cmake .. -DOPT_BUILD_BLADERF_SOURCE=ON -DOPT_BUILD_LIMESDR_SOURCE=ON -DOPT_BUILD_SDRPLAY_SOURCE=ON -DOPT_BUILD_NEW_PORTAUDIO_SINK=ON -DOPT_BUILD_M17_DECODER=ON
-make VERBOSE=1 -j2
+make VERBOSE=1 -j$(nproc)
 
 cd ..
-sh make_debian_package.sh ./build 'libfftw3-dev, libglfw3-dev, libvolk2-dev, librtaudio-dev, libzstd-dev'
+sh make_debian_package.sh ./build 'libfftw3-3, libglfw3, libvolk2.2, librtaudio6, libzstd1'

--- a/docker_builds/ubuntu_jammy/do_build.sh
+++ b/docker_builds/ubuntu_jammy/do_build.sh
@@ -4,7 +4,7 @@ cd /root
 
 # Install dependencies and tools
 apt update
-apt install -y build-essential cmake git libfftw3-dev libglfw3-dev libvolk2-dev libzstd-dev libsoapysdr-dev libairspyhf-dev libairspy-dev \
+apt install -y build-essential cmake git lsb-release libfftw3-dev libglfw3-dev libvolk2-dev libzstd-dev libsoapysdr-dev libairspyhf-dev libairspy-dev \
             libiio-dev libad9361-dev librtaudio-dev libhackrf-dev librtlsdr-dev libbladerf-dev liblimesuite-dev p7zip-full wget portaudio19-dev \
             libcodec2-dev
 

--- a/docker_builds/ubuntu_jammy/do_build.sh
+++ b/docker_builds/ubuntu_jammy/do_build.sh
@@ -3,8 +3,8 @@ set -e
 cd /root
 
 # Install dependencies and tools
-apt update
-apt install -y build-essential cmake git lsb-release libfftw3-dev libglfw3-dev libvolk2-dev libzstd-dev libsoapysdr-dev libairspyhf-dev libairspy-dev \
+apt-get update
+apt-get install -y build-essential cmake git lsb-release libfftw3-dev libglfw3-dev libvolk2-dev libzstd-dev libsoapysdr-dev libairspyhf-dev libairspy-dev \
             libiio-dev libad9361-dev librtaudio-dev libhackrf-dev librtlsdr-dev libbladerf-dev liblimesuite-dev p7zip-full wget portaudio19-dev \
             libcodec2-dev
 
@@ -19,7 +19,7 @@ cd SDRPlusPlus
 mkdir build
 cd build
 cmake .. -DOPT_BUILD_BLADERF_SOURCE=ON -DOPT_BUILD_LIMESDR_SOURCE=ON -DOPT_BUILD_SDRPLAY_SOURCE=ON -DOPT_BUILD_NEW_PORTAUDIO_SINK=ON -DOPT_BUILD_M17_DECODER=ON
-make VERBOSE=1 -j2
+make VERBOSE=1 -j$(nproc)
 
 cd ..
-sh make_debian_package.sh ./build 'libfftw3-dev, libglfw3-dev, libvolk2-dev, librtaudio-dev, libzstd-dev'
+sh make_debian_package.sh ./build 'libfftw3-3, libglfw3, libvolk2.5, librtaudio6, libzstd1'

--- a/make_debian_package.sh
+++ b/make_debian_package.sh
@@ -1,29 +1,37 @@
 #!/bin/sh
+set -e
+
+BUILDDIR=$1
+DEPENDS=$2
+DISTRO=$(lsb_release -sc)
+ARCH=$(dpkg --print-architecture)
 
 # Create directory structure
+PKGDIR="sdrpp_${DISTRO}_$ARCH"
 echo Create directory structure
-mkdir sdrpp_debian_amd64
-mkdir sdrpp_debian_amd64/DEBIAN
+mkdir -p "$PKGDIR/DEBIAN"
 
 # Create package info
 echo Create package info
-echo Package: sdrpp >> sdrpp_debian_amd64/DEBIAN/control
-echo Version: 1.1.0$BUILD_NO >> sdrpp_debian_amd64/DEBIAN/control
-echo Maintainer: Ryzerth >> sdrpp_debian_amd64/DEBIAN/control
-echo Architecture: all >> sdrpp_debian_amd64/DEBIAN/control
-echo Description: Bloat-free SDR receiver software >> sdrpp_debian_amd64/DEBIAN/control
-echo Depends: $2 >> sdrpp_debian_amd64/DEBIAN/control
+{
+    echo "Package: sdrpp"
+    echo "Version: 1.1.0$BUILD_NO"
+    echo "Maintainer: Ryzerth"
+    echo "Architecture: $ARCH"
+    echo "Description: Bloat-free SDR receiver software"
+    echo "Depends: $DEPENDS"
+} >> "$PKGDIR/DEBIAN/control"
 
 # Copying files
 ORIG_DIR=$PWD
-cd $1
-make install DESTDIR=$ORIG_DIR/sdrpp_debian_amd64
-cd $ORIG_DIR
+cd "$BUILDDIR"
+make install DESTDIR="$ORIG_DIR/$PKGDIR"
+cd "$ORIG_DIR"
 
 # Create package
 echo Create package
-dpkg-deb --build sdrpp_debian_amd64
+dpkg-deb --build "$PKGDIR"
 
 # Cleanup
 echo Cleanup
-rm -rf sdrpp_debian_amd64
+rm -rf "$PKGDIR"


### PR DESCRIPTION
This PR improves the generation of the Debian packages that are build by the GitHub workflow:

* use `apt-get` instead of `apt`
  * `apt-get` should be preferred for scripts
* use `nproc` threads for make
  * to speed up (docker) builds, if used locally (GitHub Linux runners only use two threads, so no improvement there)
* use non-`dev` package dependencies
  * **users** don't need to install library headers and static libraries.
  * this will prevent the issue described in #718
  * this unfortunately requires more specific (and distribution-version-dependent) package names including  (e.g. `libvolk2.2` on focal, `libvolk2.5` on jammy), so a bit harder to maintain.
* adjusted workflows:
  * add distribution codename (e.g. bullseye) and architecture in .deb file name automatically
  * apply `shellcheck` recommendations to scripts

~I will need to test this on all distros, so marked as WIP~. I would appreciate help and feedback. Also, I can update the build instructions for Debian/Ubuntu users in another PR, if you wish.