### PR TITLE
Fixed "the stream is not open" error message

### DIFF
--- a/sink_modules/audio_sink/src/main.cpp
+++ b/sink_modules/audio_sink/src/main.cpp
@@ -186,8 +186,10 @@ private:
         stereoPacker.stop();
         monoPacker.out.stopReader();
         stereoPacker.out.stopReader();
-        audio.stopStream();
-        audio.closeStream();
+        if (audio.isStreamRunning())
+            audio.stopStream();
+        if (audio.isStreamOpen())
+            audio.closeStream();
         monoPacker.out.clearReadStop();
         stereoPacker.out.clearReadStop();
     }


### PR DESCRIPTION
The exact error message is:

terminate called after throwing an instance of 'RtAudioError'
  what():  RtApiPulse::stopStream(): the stream is not open!
Aborted