### PR TITLE
Fix crash starting LimeSDR source without device

### DIFF
--- a/source_modules/limesdr_source/src/main.cpp
+++ b/source_modules/limesdr_source/src/main.cpp
@@ -319,6 +319,7 @@ private:
     static void start(void* ctx) {
         LimeSDRSourceModule* _this = (LimeSDRSourceModule*)ctx;
         if (_this->running) { return; }
+        if (_this->devCount == 0) { return; }
 
         // Open device
         _this->openDev = NULL;

--- a/source_modules/limesdr_source/src/main.cpp
+++ b/source_modules/limesdr_source/src/main.cpp
@@ -319,7 +319,7 @@ private:
     static void start(void* ctx) {
         LimeSDRSourceModule* _this = (LimeSDRSourceModule*)ctx;
         if (_this->running) { return; }
-        if (_this->devCount == 0) { return; }
+        if (_this->selectedDevName.empty()) { return; }
 
         // Open device
         _this->openDev = NULL;


### PR DESCRIPTION
This change fixes crash when a LimeSDR source is started without an actual device selected.