### PR TITLE
Fix crash in LimeSDR start when the device is disconnected

### DIFF
--- a/source_modules/limesdr_source/src/main.cpp
+++ b/source_modules/limesdr_source/src/main.cpp
@@ -330,7 +330,8 @@ private:
         if (err) {
             LMS_Close(_this->openDev);
             LMS_Open(&_this->openDev, _this->devList[_this->devId], NULL);
-            if (LMS_Init(_this->openDev) != 0) {
+            if (err = LMS_Init(_this->openDev)) {
+                flog::error("Failed to re-initialize device ({})", err);
                 return;
             }
         }

--- a/source_modules/limesdr_source/src/main.cpp
+++ b/source_modules/limesdr_source/src/main.cpp
@@ -330,7 +330,9 @@ private:
         if (err) {
             LMS_Close(_this->openDev);
             LMS_Open(&_this->openDev, _this->devList[_this->devId], NULL);
-            LMS_Init(_this->openDev);
+            if (LMS_Init(_this->openDev) != 0) {
+                return;
+            }
         }
 
         flog::warn("Channel count: {0}", LMS_GetNumChannels(_this->openDev, false));


### PR DESCRIPTION
This fixes crash when a device which was enumerated on the application startup gets disconnected prior to the attempt to start the radio.

The check is done after the existing work around for the LimeSuite bug. The idea is to give it the best possible chance for the radio to start.

Possibly, the check needs needs to happen in the second LMS_Open() but ideally this needs to be verified against the original workaround scenario.