### PR TITLE
Fix LimeSDR Mini v2 radio start

### DIFF
--- a/source_modules/limesdr_source/src/main.cpp
+++ b/source_modules/limesdr_source/src/main.cpp
@@ -7,6 +7,7 @@
 #include <config.h>
 #include <gui/smgui.h>
 #include <lime/LimeSuite.h>
+#include <string.h>
 
 
 #define CONCAT(a, b) ((std::string(a) + b).c_str())
@@ -335,6 +336,15 @@ private:
 
         flog::warn("Channel count: {0}", LMS_GetNumChannels(_this->openDev, false));
 
+        // LimeSDR Mini v2 requires both receive and transmit channels to be
+        // enabled even for the receive-only applications.
+        // The name below is the inlined version of the lime::LMS_DEV_LIMESDRMINI_V2
+        // definition from the boards C++ API.
+        const lms_dev_info_t* info = LMS_GetDeviceInfo(_this->openDev);
+        if (info && strstr(info->deviceName, "LimeSDR-Mini_v2")) {
+            LMS_EnableChannel(_this->openDev, true, _this->chanId, true);
+        }
+
         // Set options
         LMS_EnableChannel(_this->openDev, false, _this->chanId, true);
         LMS_SetAntenna(_this->openDev, false, _this->chanId, _this->antennaId);
@@ -374,6 +384,7 @@ private:
         LMS_StopStream(&_this->devStream);
         LMS_DestroyStream(_this->openDev, &_this->devStream);
         LMS_EnableChannel(_this->openDev, false, _this->chanId, false);
+        LMS_EnableChannel(_this->openDev, true, _this->chanId, false);
 
         LMS_Close(_this->openDev);
 


### PR DESCRIPTION
This fixes the issue when starting LimeSDR Mini v2 radio does not really start the actual reception. The workaround was to configure the bandwidth after the radio was started.

The actual fix is to enable TX channel. This is how the demo code from LimeSuite is communicating with the v2 of the radio, and this is also was confirmed on the myriad discourse:

  https://discourse.myriadrf.org/t/limesdr-mini-v2-reading-samples-from-rx-fifo/7900/2

The TX channel is only enabled for the LimeSDR Mini v2 and not for other LimeSDR radios to avoid unwanted possible side effects. The check is performed based on the name, matching the LimeSDRTest application from the LimeSuite. The name of the board is inlined to avoid dependency of the new LMSBoard.h.

Upon the radio stop both RXC and TX channels are stopped. This is for the code simplicity. Alternative would be to rely in the LMS_Close() to disabled channels which matches the basicRX demo code from the LimeSuite. It is not really clear what is the best strategy here.