### PR TITLE
Fix installation directories

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,10 @@
 cmake_minimum_required(VERSION 3.13)
 project(sdrpp)
 
+if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+    include(GNUInstallDirs)
+endif()
+
 # Backends
 option(OPT_BACKEND_GLFW "Use the GLFW backend" ON)
 option(OPT_BACKEND_ANDROID "Use the Android backend" OFF)
@@ -303,16 +307,16 @@ endif ()
 configure_file(${CMAKE_SOURCE_DIR}/sdrpp_module.cmake ${CMAKE_CURRENT_BINARY_DIR}/sdrpp_module.cmake @ONLY)
 
 # Install directives
-install(TARGETS sdrpp DESTINATION bin)
-install(DIRECTORY ${CMAKE_SOURCE_DIR}/root/res/bandplans DESTINATION share/sdrpp)
-install(DIRECTORY ${CMAKE_SOURCE_DIR}/root/res/colormaps DESTINATION share/sdrpp)
-install(DIRECTORY ${CMAKE_SOURCE_DIR}/root/res/fonts DESTINATION share/sdrpp)
-install(DIRECTORY ${CMAKE_SOURCE_DIR}/root/res/icons DESTINATION share/sdrpp)
-install(DIRECTORY ${CMAKE_SOURCE_DIR}/root/res/themes DESTINATION share/sdrpp)
+install(TARGETS sdrpp DESTINATION ${CMAKE_INSTALL_BINDIR})
+install(DIRECTORY ${CMAKE_SOURCE_DIR}/root/res/bandplans DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/sdrpp)
+install(DIRECTORY ${CMAKE_SOURCE_DIR}/root/res/colormaps DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/sdrpp)
+install(DIRECTORY ${CMAKE_SOURCE_DIR}/root/res/fonts DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/sdrpp)
+install(DIRECTORY ${CMAKE_SOURCE_DIR}/root/res/icons DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/sdrpp)
+install(DIRECTORY ${CMAKE_SOURCE_DIR}/root/res/themes DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/sdrpp)
 configure_file(${CMAKE_SOURCE_DIR}/sdrpp.desktop ${CMAKE_CURRENT_BINARY_DIR}/sdrpp.desktop @ONLY)
 
 if (${CMAKE_SYSTEM_NAME} MATCHES "Linux")
-    install(FILES ${CMAKE_CURRENT_BINARY_DIR}/sdrpp.desktop DESTINATION share/applications)
+    install(FILES ${CMAKE_CURRENT_BINARY_DIR}/sdrpp.desktop DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/applications)
 endif ()
 
 # Create uninstall target

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -168,4 +168,4 @@ set(CORE_FILES ${RUNTIME_OUTPUT_DIRECTORY} PARENT_SCOPE)
 # cmake .. "-DCMAKE_TOOLCHAIN_FILE=C:/dev/vcpkg/scripts/buildsystems/vcpkg.cmake"
 
 # Install directives
-install(TARGETS sdrpp_core DESTINATION lib)
+install(TARGETS sdrpp_core DESTINATION ${CMAKE_INSTALL_LIBDIR})

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -36,6 +36,9 @@ target_compile_options(sdrpp_core PRIVATE ${SDRPP_COMPILER_FLAGS})
 # Set the install prefix
 target_compile_definitions(sdrpp_core PUBLIC INSTALL_PREFIX="${CMAKE_INSTALL_PREFIX}")
 
+# Set the plugin prefix
+target_compile_definitions(sdrpp_core PUBLIC PLUGINS_PREFIX="${CMAKE_INSTALL_FULL_LIBDIR}")
+
 # Include core headers
 target_include_directories(sdrpp_core PUBLIC "src/")
 target_include_directories(sdrpp_core PUBLIC "src/imgui")

--- a/core/libcorrect/CMakeLists.txt
+++ b/core/libcorrect/CMakeLists.txt
@@ -92,8 +92,8 @@ add_subdirectory(tools)
 # add_subdirectory(benchmarks)
 
 # install(TARGETS correct correct_static
-#         DESTINATION lib)
-# install(FILES ${INSTALL_HEADERS} DESTINATION "${CMAKE_INSTALL_PREFIX}/include")
+#         DESTINATION ${CMAKE_INSTALL_LIBDIR})
+# install(FILES ${INSTALL_HEADERS} DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
 
 add_library(fec_shim_static EXCLUDE_FROM_ALL src/fec_shim.c ${correct_obj_files})
 set_target_properties(fec_shim_static PROPERTIES OUTPUT_NAME "fec")
@@ -103,6 +103,6 @@ add_custom_target(fec-shim-h COMMAND ${CMAKE_COMMAND} -E copy ${PROJECT_SOURCE_D
 add_custom_target(shim DEPENDS fec_shim_static fec_shim_shared fec-shim-h)
 
 # install(TARGETS fec_shim_static fec_shim_shared
-#         DESTINATION lib
+#         DESTINATION ${CMAKE_INSTALL_LIBDIR}
 #         OPTIONAL)
-# install(FILES ${PROJECT_BINARY_DIR}/include/fec.h DESTINATION "${CMAKE_INSTALL_PREFIX}/include" OPTIONAL)
+# install(FILES ${PROJECT_BINARY_DIR}/include/fec.h DESTINATION "${CMAKE_INSTALL_INCLUDEDIR} OPTIONAL)

--- a/core/src/core.cpp
+++ b/core/src/core.cpp
@@ -32,6 +32,14 @@
 #endif
 #endif
 
+#ifndef PLUGINS_PREFIX
+#ifdef __APPLE__
+#define PLUGINS_PREFIX "/usr/local/lib"
+#else
+#define PLUGINS_PREFIX "/usr/lib"
+#endif
+#endif
+
 namespace core {
     ConfigManager configManager;
     ModuleManager moduleManager;
@@ -254,7 +262,7 @@ int sdrpp_main(int argc, char* argv[]) {
     defConfig["modulesDirectory"] = root + "/modules";
     defConfig["resourcesDirectory"] = root + "/res";
 #else
-    defConfig["modulesDirectory"] = INSTALL_PREFIX "/lib/sdrpp/plugins";
+    defConfig["modulesDirectory"] = PLUGINS_PREFIX "/sdrpp/plugins";
     defConfig["resourcesDirectory"] = INSTALL_PREFIX "/share/sdrpp";
 #endif
 

--- a/sdrpp_module.cmake
+++ b/sdrpp_module.cmake
@@ -16,4 +16,4 @@ set_target_properties(${PROJECT_NAME} PROPERTIES PREFIX "")
 target_compile_options(${PROJECT_NAME} PRIVATE ${SDRPP_MODULE_COMPILER_FLAGS})
 
 # Install directives
-install(TARGETS ${PROJECT_NAME} DESTINATION lib/sdrpp/plugins)
+install(TARGETS ${PROJECT_NAME} DESTINATION ${CMAKE_INSTALL_LIBDIR}/sdrpp/plugins)


### PR DESCRIPTION
The library path is hardcoded to `/usr/lib` (or `/usr/local/lib` depending on the chosen prefix). But depending on the architecture, libraries must be installed in `/usr/lib64`. CMake provides variables which handle this case discriminations. This PR replaces the hardcoded values by these variables.