### PR TITLE
use unique sink module names

### DIFF
--- a/sink_modules/portaudio_sink/CMakeLists.txt
+++ b/sink_modules/portaudio_sink/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.13)
-project(audio_sink)
+project(portaudio_sink)
 
 file(GLOB SRC "src/*.cpp")
 
@@ -7,16 +7,16 @@ include(${SDRPP_MODULE_CMAKE})
 
 if (MSVC)
     find_package(portaudio CONFIG REQUIRED)
-    target_link_libraries(audio_sink PRIVATE portaudio)
+    target_link_libraries(portaudio_sink PRIVATE portaudio)
 else (MSVC)
     find_package(PkgConfig)
 
     pkg_check_modules(PORTAUDIO REQUIRED portaudio-2.0)
 
-    target_include_directories(audio_sink PRIVATE ${PORTAUDIO_INCLUDE_DIRS})
+    target_include_directories(portaudio_sink PRIVATE ${PORTAUDIO_INCLUDE_DIRS})
 
-    target_link_directories(audio_sink PRIVATE ${PORTAUDIO_LIBRARY_DIRS})
+    target_link_directories(portaudio_sink PRIVATE ${PORTAUDIO_LIBRARY_DIRS})
 
-    target_link_libraries(audio_sink PRIVATE ${PORTAUDIO_LIBRARIES})
+    target_link_libraries(portaudio_sink PRIVATE ${PORTAUDIO_LIBRARIES})
 
 endif (MSVC)

--- a/sink_modules/portaudio_sink/src/main.cpp
+++ b/sink_modules/portaudio_sink/src/main.cpp
@@ -12,7 +12,7 @@
 #define CONCAT(a, b) ((std::string(a) + b).c_str())
 
 SDRPP_MOD_INFO{
-    /* Name:            */ "audio_sink",
+    /* Name:            */ "portaudio_sink",
     /* Description:     */ "Audio sink module for SDR++",
     /* Author:          */ "Ryzerth",
     /* Version:         */ 0, 1, 0,


### PR DESCRIPTION
Both `audio_sink` and `portaudio_sink` use `audio_sink` as CMake project identifier. This leads to a CMake error if both `OPT_BUILD_AUDIO_SINK` and `OPT_BUILD_PORTAUDIO_SINK` are enabled:

```
-- The C compiler identification is GNU 12.2.1
-- The CXX compiler identification is GNU 12.2.1
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /usr/bin/x86_64-pc-linux-gnu-gcc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/x86_64-pc-linux-gnu-g++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
CMake Deprecation Warning at core/libcorrect/CMakeLists.txt:1 (cmake_minimum_required):
  Compatibility with CMake < 2.8.12 will be removed from a future version of
  CMake.

  Update the VERSION argument <min> value or use a ...<max> suffix to tell
  CMake that the project does not need compatibility with older versions.


-- Performing Test COMPILER_SUPPORTS_WPEDANTIC
-- Performing Test COMPILER_SUPPORTS_WPEDANTIC - Success
-- Looking for dotprod in FEC
-- Looking for dotprod in FEC - not found
-- Performing Test HAVE_SSE
-- Performing Test HAVE_SSE - Success
-- Found PkgConfig: /usr/bin/x86_64-pc-linux-gnu-pkg-config (found version "1.8.1") 
-- Checking for module 'glfw3'
--   Found glfw3, version 3.3.8
-- Found OpenGL: /usr/lib64/libOpenGL.so   
-- Checking for module 'fftw3f'
--   Found fftw3f, version 3.3.10
-- Checking for module 'volk'
--   Found volk, version 2.5
-- Checking for module 'libzstd'
--   Found libzstd, version 1.5.4
-- Checking for module 'rtaudio'
--   Found rtaudio, version 5.2.0
-- Checking for module 'libhackrf'
--   Found libhackrf, version 0.7
-- Checking for module 'librtlsdr'
--   Found librtlsdr, version 0.6.0_p20200802
-- Checking for module 'libusb-1.0'
--   Found libusb-1.0, version 1.0.26
-- Checking for module 'libiio'
--   Found libiio, version 0.24
-- Checking for module 'libad9361'
--   Found libad9361, version 0.2
CMake Error at sdrpp_module.cmake:10 (add_library):
  add_library cannot create target "audio_sink" because another target with
  the same name already exists.  The existing target is a shared library
  created in source directory
  "/var/tmp/portage/net-wireless/sdrpp-9999/work/sdrpp-9999/sink_modules/audio_sink".
  See documentation for policy CMP0002 for more details.
Call Stack (most recent call first):
  sink_modules/portaudio_sink/CMakeLists.txt:6 (include)
```

In case this is a copy-and-paste-type, this PR replaces the identifiers by unique values.