### PR TITLE
Fix jack audio repeating bug

### DIFF
--- a/sink_modules/audio_sink/src/main.cpp
+++ b/sink_modules/audio_sink/src/main.cpp
@@ -9,7 +9,7 @@
 #include <RtAudio.h>
 #include <config.h>
 #include <core.h>
-
+#include <string.h>
 #define CONCAT(a, b) ((std::string(a) + b).c_str())
 
 SDRPP_MOD_INFO{
@@ -201,9 +201,13 @@ private:
         //     if (_this->stereoPacker.out.readBuf[i].l == INFINITY || _this->stereoPacker.out.readBuf[i].r == INFINITY) { flog::error("INFINITY in audio data"); }
         //     if (_this->stereoPacker.out.readBuf[i].l == -INFINITY || _this->stereoPacker.out.readBuf[i].r == -INFINITY) { flog::error("-INFINITY in audio data"); }
         // }
-
+        if(!gui::mainWindow.isPlaying()) {
+            memset(outputBuffer, 0, nBufferFrames * sizeof(dsp::stereo_t));
+            return 0;
+        }
         memcpy(outputBuffer, _this->stereoPacker.out.readBuf, nBufferFrames * sizeof(dsp::stereo_t));
         _this->stereoPacker.out.flush();
+        
         return 0;
     }
 


### PR DESCRIPTION
If you run SDRPlusPlus with jack using the regular audio_sink module and stop the playback, the audio keeps repeating as the buffer is never cleared. This does not occur under portaudio.
The only possible issue with this fix is that it keeps clearing the buffer over and over again, but the portaudio sink module does this too.