### PR TITLE
Add missing includes

### DIFF
--- a/core/src/gui/smgui.h
+++ b/core/src/gui/smgui.h
@@ -1,6 +1,7 @@
 #pragma once
 #include <stdint.h>
 #include <imgui.h>
+#include <stdint.h>
 #include <string>
 #include <vector>
 #include <map>

--- a/core/src/utils/net.h
+++ b/core/src/utils/net.h
@@ -4,6 +4,7 @@
 #include <mutex>
 #include <memory>
 #include <map>
+#include <stdexcept>
 
 #ifdef _WIN32
 #include <WinSock2.h>


### PR DESCRIPTION
My branch fails to compile on latest Arch with two errors. Your master compiles fine, but better do this to prevent some possible future confusion.
```
SDRPlusPlus/core/src/utils/net.cpp:71:24: error: ‘runtime_error’ is not a member of ‘std’
   71 |             throw std::runtime_error("Unknown host");

SDRPlusPlus/core/src/gui/smgui.h:89:49: error: ‘uint8_t’ has not been declared
   89 |         static int loadItem(DrawListElem& elem, uint8_t* data, int len);
```

EDIT: Wait, maybe I'm retarded.
