### PR TITLE
Workaround for RtAudio Exception when no Input are connected on Input MIC on some PC

### DIFF
--- a/sink_modules/audio_sink/src/main.cpp
+++ b/sink_modules/audio_sink/src/main.cpp
@@ -45,16 +45,20 @@ public:
         int count = audio.getDeviceCount();
         RtAudio::DeviceInfo info;
         for (int i = 0; i < count; i++) {
-            info = audio.getDeviceInfo(i);
-            if (!info.probed) { continue; }
-            if (info.outputChannels == 0) { continue; }
-            if (info.isDefaultOutput) { defaultDevId = devList.size(); }
-            devList.push_back(info);
-            deviceIds.push_back(i);
-            txtDevList += info.name;
-            txtDevList += '\0';
+            try {
+                info = audio.getDeviceInfo(i);
+                if (!info.probed) { continue; }
+                if (info.outputChannels == 0) { continue; }
+                if (info.isDefaultOutput) { defaultDevId = devList.size(); }
+                devList.push_back(info);
+                deviceIds.push_back(i);
+                txtDevList += info.name;
+                txtDevList += '\0';
+            }
+            catch (std::exception e) {
+            flog::error("AudioSinkModule Error getting audio device info: {0}", e.what());
+            }
         }
-
         selectByName(device);
     }
 

--- a/sink_modules/audio_sink/src/main.cpp
+++ b/sink_modules/audio_sink/src/main.cpp
@@ -56,7 +56,7 @@ public:
                 txtDevList += '\0';
             }
             catch (std::exception e) {
-            flog::error("AudioSinkModule Error getting audio device info: {0}", e.what());
+                flog::error("AudioSinkModule Error getting audio device info: {0}", e.what());
             }
         }
         selectByName(device);


### PR DESCRIPTION
Workaround for RtAudio Exception when no Input are connected on Input MIC on some PC
Issue reproduced with Windows11 Pro + ROG CROSSHAIR X670E HERO Workaround for RtAudio just add try/catch and log the error but allow to start SDR++

It is a very basic / minimal code change which is similar to what was already done in https://github.com/AlexandreRouma/SDRPlusPlus/blob/master/source_modules/audio_source/src/main.cpp#L88