### PR TITLE
gh workflow: fix build on Debian sid (current 13) libvolk-dev now is 3.0 ver

### DIFF
--- a/docker_builds/debian_sid/do_build.sh
+++ b/docker_builds/debian_sid/do_build.sh
@@ -4,7 +4,7 @@ cd /root
 
 # Install dependencies and tools
 apt update
-apt install -y build-essential cmake git libfftw3-dev libglfw3-dev libvolk2-dev libzstd-dev libsoapysdr-dev libairspyhf-dev libairspy-dev \
+apt install -y build-essential cmake git libfftw3-dev libglfw3-dev libvolk-dev libzstd-dev libsoapysdr-dev libairspyhf-dev libairspy-dev \
             libiio-dev libad9361-dev librtaudio-dev libhackrf-dev librtlsdr-dev libbladerf-dev liblimesuite-dev p7zip-full wget portaudio19-dev \
             libcodec2-dev autoconf libtool xxd
 
@@ -32,4 +32,4 @@ cmake .. -DOPT_BUILD_BLADERF_SOURCE=ON -DOPT_BUILD_LIMESDR_SOURCE=ON -DOPT_BUILD
 make VERBOSE=1 -j2
 
 cd ..
-sh make_debian_package.sh ./build 'libfftw3-dev, libglfw3-dev, libvolk2-dev, librtaudio-dev, libzstd-dev'
+sh make_debian_package.sh ./build 'libfftw3-dev, libglfw3-dev, libvolk-dev, librtaudio-dev, libzstd-dev'


### PR DESCRIPTION
If I understand correctly, libvolk-dev in Debian Sid (currently) is version 3.0 https://packages.debian.org/sid/libvolk-dev
and libvolk2-dev is no longer available
Replace libvolk2-dev to libvolk-dev