### PR TITLE
Update usa.json bandplan with MURS frequencies

### DIFF
--- a/root/res/bandplans/usa.json
+++ b/root/res/bandplans/usa.json
@@ -228,6 +228,18 @@
             "end": 148000000
         },
         {
+            "name": "MURS (lower)",
+            "type": "amateur",
+            "start": 151820000,
+            "end": 151940000
+        },
+        {
+            "name": "MURS (upper)",
+            "type": "amateur",
+            "start": 154570000,
+            "end": 154600000
+        },
+        {
             "name": "Marine",
             "type": "marine",
             "start": 156000000,


### PR DESCRIPTION
Added MURS frequencies to USA bandplan
Source: [FCC Title 47 - Part 95 - Subpart J](https://www.ecfr.gov/current/title-47/chapter-I/subchapter-D/part-95/subpart-J) , [PDF Version](https://www.govinfo.gov/content/pkg/CFR-2009-title47-vol5/pdf/CFR-2009-title47-vol5-part95.pdf)

Used the "lower"/"upper" naming standard used in other split bands due to this band being right in between public safety frequencies and business band usage.

This is similar to the GMRS/FRS bands.

MURS is "channelized" and I used the channel centers as the upper and lower bounds of the band definitions. Channel widths are 11.25 kHz and 20 kHz, but adding those bumpers to the upper and lower bounds seems messy and does not follow what the other band definitions seem to use.

# Important

Only minor bug fixes and bandplans are accepted.

Pull requests adding features or any bug fix that requires significant code changes will be automatically rejected.

Open an issue requesting a feature or discussing a possible bugfix instead.