### PR TITLE
Add 8m - Amateur to the Belgian Bandplan

### DIFF
--- a/root/res/bandplans/belgium.json
+++ b/root/res/bandplans/belgium.json
@@ -150,6 +150,12 @@
       "end": 29700000
     },
     {
+      "name": "8m - Amateur",
+      "type": "amateur",
+      "start": 40660000,
+      "end": 40690000
+    },
+    {
       "name": "6m - Amateur",
       "type": "amateur",
       "start": 50000000,


### PR DESCRIPTION
In this decision the BIPT allows holders of a class A operator’s certificate to use the frequency spectrum 40.66 MHz – 40.69 MHz under certain conditions.

https://www.bipt.be/consumers/publication/decision-of-29-august-2023-regarding-the-allocation-of-the-40660-mhz-40690-mhz-spectrum-to-private-radio-stations-for-individual-training-technical-exchange-of-messages-and-studies-used-by-radio-amateurs