### PR TITLE
Increase bandwidth to 60k

### DIFF
--- a/decoder_modules/radio/src/demodulators/am.h
+++ b/decoder_modules/radio/src/demodulators/am.h
@@ -73,7 +73,7 @@ namespace demod {
         // ============= INFO =============
 
         const char* getName() { return "AM"; }
-        double getIFSampleRate() { return 15000.0; }
+        double getIFSampleRate() { return 60000.0; }
         double getAFSampleRate() { return getIFSampleRate(); }
         double getDefaultBandwidth() { return 10000.0; }
         double getMinBandwidth() { return 1000.0; }


### PR DESCRIPTION
Some amateur AM middle wave stations are much wider than 15k. It's nice to have the range to widen it.
