### PR TITLE
Load custom bandplans

### DIFF
--- a/core/src/core.cpp
+++ b/core/src/core.cpp
@@ -362,6 +362,9 @@ int sdrpp_main(int argc, char* argv[]) {
     LoadingScreen::show("Loading band plans");
     flog::info("Loading band plans");
     bandplan::loadFromDir(resDir + "/bandplans");
+#if !defined(_WIN32) && !defined(IS_MACOS_BUNDLE) && !defined(__ANDROID__)
+    bandplan::loadFromDir(root + "/bandplans", true);
+#endif
 
     LoadingScreen::show("Loading band plan colors");
     flog::info("Loading band plans color table");

--- a/core/src/gui/widgets/bandplan.cpp
+++ b/core/src/gui/widgets/bandplan.cpp
@@ -89,7 +89,7 @@ namespace bandplan {
         generateTxt();
     }
 
-    void loadFromDir(std::string path) {
+    void loadFromDir(std::string path, bool append) {
         if (!std::filesystem::exists(path)) {
             flog::error("Band Plan directory does not exist");
             return;
@@ -98,7 +98,9 @@ namespace bandplan {
             flog::error("Band Plan directory isn't a directory...");
             return;
         }
-        bandplans.clear();
+        if (!append) {
+            bandplans.clear();
+        }
         for (const auto& file : std::filesystem::directory_iterator(path)) {
             std::string path = file.path().generic_string();
             if (file.path().extension().generic_string() != ".json") {

--- a/core/src/gui/widgets/bandplan.h
+++ b/core/src/gui/widgets/bandplan.h
@@ -37,7 +37,7 @@ namespace bandplan {
     void from_json(const json& j, BandPlanColor_t& ct);
 
     void loadBandPlan(std::string path);
-    void loadFromDir(std::string path);
+    void loadFromDir(std::string path, bool append = false);
     void loadColorTable(json table);
 
     extern std::map<std::string, BandPlan_t> bandplans;


### PR DESCRIPTION
Load custom bandplans (located in "$HOME/.config/sdrpp/bandplans/" on Unix-like systems) in addition to the default bandplans.
