### PR TITLE
Fix JACK audio repeating bug

### DIFF
--- a/core/src/gui/main_window.cpp
+++ b/core/src/gui/main_window.cpp
@@ -682,6 +682,8 @@ void MainWindow::setPlayState(bool _playing) {
         playing = false;
         onPlayStateChange.emit(false);
         sigpath::sourceManager.stop();
+        sigpath::sinkManager.stopStream("Radio");
+        sigpath::sinkManager.startStream("Radio");
         sigpath::iqFrontEnd.flushInputBuffer();
     }
 }


### PR DESCRIPTION
# Fix JACK audio repeating bug

#### This pull request fixes a bug where if you use native JACK _(It doesn't happen with pipewire-jack IIRC)_ and pause the SDR it keeps playing whatever was last in the buffer and creates a very unpleasant noise.

I have made a pull request for this issue before back in April, but that fix was less than ideal, as it kept clearing the buffer over and over again, after it was already cleared. While trying to find a better solution I discovered that the `doStop()` function in the audio_sink is seemingly not always called on pause(?). This PR adds that call.

Another issue with the previous PR was that it completely prevented any audio playback through the sink while the SDR was stopped, which was a planned feature with a sink rewrite. This PR shouldn't prevent that, though the solution for this is _slightly janky_, it just immediately restarts the sink after stopping it. This could cause issues if one was to manually route SDRPlusPlus, where it would lose that connection, but this is easily fixable using the QJackCtl's patchbay, making it automatically connect wherever it needs to.

#### If there's any issues that I'm blind to, like there being a very specific reason doStop() isn't called, please let me know.