### PR TITLE
add additional library to debian install instructions

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -44,7 +44,7 @@ Download the latest release from [the Releases page](https://github.com/Alexandr
 Then, run:
 
 ```sh
-sudo apt install libfftw3-dev libglfw3-dev libvolk2-dev libsoapysdr-dev libairspyhf-dev libiio-dev libad9361-dev librtaudio-dev libhackrf-dev
+sudo apt install libfftw3-dev libglfw3-dev libvolk2-dev libzstd-dev libsoapysdr-dev libairspyhf-dev libiio-dev libad9361-dev librtaudio-dev libhackrf-dev
 sudo dpkg -i sdrpp_debian_amd64.deb
 ```
 


### PR DESCRIPTION
I tried installing on a fresh install of Ubuntu 22 and `dpkg -i` failed due to `libzstd-dev` not being installed.  After installing it worked fine.