### PR TITLE
Make compatible with rtaudio API 5 and 6.

### DIFF
--- a/sink_modules/audio_sink/src/main.cpp
+++ b/sink_modules/audio_sink/src/main.cpp
@@ -164,8 +164,7 @@ public:
     }
 
 #if RTAUDIO_VERSION_MAJOR >= 6
-    static void reportErrorsAsException(RtAudioErrorType type,
-                                        const std::string& errorText) {
+    static void reportErrorsAsException(RtAudioErrorType type, const std::string& errorText) {
         switch (type) {
         case RtAudioErrorType::RTAUDIO_NO_ERROR:
             return;

--- a/source_modules/audio_source/src/main.cpp
+++ b/source_modules/audio_source/src/main.cpp
@@ -263,8 +263,7 @@ private:
     }
 
 #if RTAUDIO_VERSION_MAJOR >= 6
-    static void reportErrorsAsException(RtAudioErrorType type,
-                                        const std::string& errorText) {
+    static void reportErrorsAsException(RtAudioErrorType type, const std::string& errorText) {
         switch (type) {
         case RtAudioErrorType::RTAUDIO_NO_ERROR:
             return;


### PR DESCRIPTION
Recent rtaudio changed the API to not throw exceptions anymore and also have DeviceIDs not queried by index but IDs that are provided separately ( https://github.com/thestk/rtaudio/releases ).

Adapt the code-base to be compatible with the old and the new API as we have to exepect that in a transition period both APIs are common on various build platforms.
