### PR TITLE
Make it easier to contribute: add .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+# Editor config file, see http://editorconfig.org/
+root = true
+
+[*]
+charset = utf-8
+indent_style = space
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.{h,cpp}]
+indent_size = 4
+
+[Makefile]
+indent_style = tab


### PR DESCRIPTION
http://editorconfig.org/
The .editorconfig, which is a common way to tell IDEs and editors basic expectations such as indentation of code. Almost every editor supports that and people have it configured.

Set the configuration to the observed 4 space indent for c++ code.

That way, code contributions will automatically adhere to the basic formatting even if not evaluating .clang-format.