### PR TITLE
Fixed spectran_http_source

### DIFF
--- a/source_modules/spectran_http_source/src/main.cpp
+++ b/source_modules/spectran_http_source/src/main.cpp
@@ -68,6 +68,11 @@ public:
             strcpy(hostname, hostStr.c_str());
         }
 
+        if (config.conf[name].contains("demodulatorBlockApiName")) {
+            std::string demodulatorBlockApiNameStr = config.conf[name]["demodulatorBlockApiName"] ;
+            strcpy(demodulatorBlockApiName, demodulatorBlockApiNameStr.c_str());
+        }
+
         if (config.conf[name].contains("port")) {
             port = config.conf[name]["port"];
             port = std::clamp<int>(port, 1, 65535);

--- a/source_modules/spectran_http_source/src/main.cpp
+++ b/source_modules/spectran_http_source/src/main.cpp
@@ -186,7 +186,7 @@ private:
 
         if (connected) { SmGui::BeginDisabled(); }
 
-        ImGui::LeftLabel("rate");
+        ImGui::LeftLabel("Rate");
         if (SmGui::Combo(CONCAT("##spectran_sr_sel_", _this->name), &_this->srId, _this->sampleRateListTxt.c_str())) {
             flog::debug("Setting requested sample rate: {}", sampleRates[_this->srId]);
             _this->sampleRateRequested = sampleRates[_this->srId];
@@ -196,23 +196,23 @@ private:
             config.release(true);
         }        
         
-        ImGui::LeftLabel("host");
+        ImGui::LeftLabel("Host");
         if (SmGui::InputText(CONCAT("##spectran_http_host_", _this->name), _this->hostname, 1023)) {
             config.acquire();
             config.conf[_this->name]["hostname"] = _this->hostname;
             config.release(true);
         }
-        
+
         SmGui::SameLine();
         SmGui::FillWidth();
-        ImGui::LeftLabel("port");
+        ImGui::LeftLabel("Port");
         if (SmGui::InputInt(CONCAT("##spectran_http_port_", _this->name), &_this->port, 0, 0)) {
             config.acquire();
             config.conf[_this->name]["port"] = _this->port;
             config.release(true);
         }
 
-        ImGui::LeftLabel("demod block");
+        ImGui::LeftLabel("Demod Block");
         if (SmGui::InputText(CONCAT("##spectran_demodulator_block_api_name_", _this->name), _this->demodulatorBlockApiName, 1023)) {
             config.acquire();
             config.conf[_this->name]["demodulatorBlockApiName"] = _this->demodulatorBlockApiName;

--- a/source_modules/spectran_http_source/src/main.cpp
+++ b/source_modules/spectran_http_source/src/main.cpp
@@ -186,6 +186,7 @@ private:
 
         if (connected) { SmGui::BeginDisabled(); }
 
+        ImGui::LeftLabel("rate");
         if (SmGui::Combo(CONCAT("##spectran_sr_sel_", _this->name), &_this->srId, _this->sampleRateListTxt.c_str())) {
             flog::debug("Setting requested sample rate: {}", sampleRates[_this->srId]);
             _this->sampleRateRequested = sampleRates[_this->srId];
@@ -195,20 +196,23 @@ private:
             config.release(true);
         }        
         
+        ImGui::LeftLabel("host");
         if (SmGui::InputText(CONCAT("##spectran_http_host_", _this->name), _this->hostname, 1023)) {
             config.acquire();
             config.conf[_this->name]["hostname"] = _this->hostname;
             config.release(true);
         }
+        
         SmGui::SameLine();
-
         SmGui::FillWidth();
+        ImGui::LeftLabel("port");
         if (SmGui::InputInt(CONCAT("##spectran_http_port_", _this->name), &_this->port, 0, 0)) {
             config.acquire();
             config.conf[_this->name]["port"] = _this->port;
             config.release(true);
         }
 
+        ImGui::LeftLabel("demod block");
         if (SmGui::InputText(CONCAT("##spectran_demodulator_block_api_name_", _this->name), _this->demodulatorBlockApiName, 1023)) {
             config.acquire();
             config.conf[_this->name]["demodulatorBlockApiName"] = _this->demodulatorBlockApiName;

--- a/source_modules/spectran_http_source/src/spectran_http_client.h
+++ b/source_modules/spectran_http_source/src/spectran_http_client.h
@@ -9,7 +9,7 @@
 
 class SpectranHTTPClient {
 public:
-    SpectranHTTPClient(std::string host, int port, dsp::stream<dsp::complex_t>* stream);
+    SpectranHTTPClient(std::string host, int port, dsp::stream<dsp::complex_t>* stream, double sampleRateRequested, std::string demodulatorBlockApiName);
 
     void startWorker();
     void streaming(bool enabled);
@@ -24,8 +24,9 @@ public:
 private:
     void worker();
 
-    std::string host;
-    int port;
+    std::string _host;
+    int _port;
+    std::string _demodulatorBlockApiName;
 
     std::shared_ptr<net::Socket> sock;
     net::http::Client http;
@@ -35,4 +36,6 @@ private:
     bool streamingEnabled = false;
     int64_t _centerFreq = 0;
     uint64_t _samplerate = 0;
+    uint64_t _sampleRateRequested = 1000000;
+    
 };


### PR DESCRIPTION
Fixed spectran_http_source block to work poperly with the IQ Demodulator Block, as intended by the Aaronia RTSA Suite HTTP API design.

Also introduced fixed / realistic sample rates to be used withing a network environment.