### PR TITLE
added window icon support for wayland

### DIFF
--- a/core/backends/glfw/backend.cpp
+++ b/core/backends/glfw/backend.cpp
@@ -99,8 +99,10 @@ namespace backend {
             glfwWindowHint(GLFW_CLIENT_API, OPENGL_VERSIONS_IS_ES[i] ? GLFW_OPENGL_ES_API : GLFW_OPENGL_API);
             glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, OPENGL_VERSIONS_MAJOR[i]);
             glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, OPENGL_VERSIONS_MINOR[i]);
-            glfwWindowHintString(GLFW_WAYLAND_APP_ID, "sdrpp");
-
+             #if GLFW_VERSION_MAJOR > 3 || (GLFW_VERSION_MAJOR == 3 && GLFW_VERSION_MINOR >= 4)
+                glfwWindowHintString(GLFW_WAYLAND_APP_ID, "sdrpp");
+            #endif
+            
             // Create window with graphics context
             monitor = glfwGetPrimaryMonitor();
             window = glfwCreateWindow(winWidth, winHeight, "SDR++ v" VERSION_STR " (Built at " __TIME__ ", " __DATE__ ")", NULL, NULL);

--- a/core/backends/glfw/backend.cpp
+++ b/core/backends/glfw/backend.cpp
@@ -99,6 +99,7 @@ namespace backend {
             glfwWindowHint(GLFW_CLIENT_API, OPENGL_VERSIONS_IS_ES[i] ? GLFW_OPENGL_ES_API : GLFW_OPENGL_API);
             glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, OPENGL_VERSIONS_MAJOR[i]);
             glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, OPENGL_VERSIONS_MINOR[i]);
+            glfwWindowHintString(GLFW_WAYLAND_APP_ID, "SDR++");
 
             // Create window with graphics context
             monitor = glfwGetPrimaryMonitor();

--- a/core/backends/glfw/backend.cpp
+++ b/core/backends/glfw/backend.cpp
@@ -99,9 +99,9 @@ namespace backend {
             glfwWindowHint(GLFW_CLIENT_API, OPENGL_VERSIONS_IS_ES[i] ? GLFW_OPENGL_ES_API : GLFW_OPENGL_API);
             glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, OPENGL_VERSIONS_MAJOR[i]);
             glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, OPENGL_VERSIONS_MINOR[i]);
-             #if GLFW_VERSION_MAJOR > 3 || (GLFW_VERSION_MAJOR == 3 && GLFW_VERSION_MINOR >= 4)
+    #if GLFW_VERSION_MAJOR > 3 || (GLFW_VERSION_MAJOR == 3 && GLFW_VERSION_MINOR >= 4)
                 glfwWindowHintString(GLFW_WAYLAND_APP_ID, "sdrpp");
-            #endif
+    #endif
             
             // Create window with graphics context
             monitor = glfwGetPrimaryMonitor();

--- a/core/backends/glfw/backend.cpp
+++ b/core/backends/glfw/backend.cpp
@@ -99,7 +99,7 @@ namespace backend {
             glfwWindowHint(GLFW_CLIENT_API, OPENGL_VERSIONS_IS_ES[i] ? GLFW_OPENGL_ES_API : GLFW_OPENGL_API);
             glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, OPENGL_VERSIONS_MAJOR[i]);
             glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, OPENGL_VERSIONS_MINOR[i]);
-            glfwWindowHintString(GLFW_WAYLAND_APP_ID, "SDR++");
+            glfwWindowHintString(GLFW_WAYLAND_APP_ID, "sdrpp");
 
             // Create window with graphics context
             monitor = glfwGetPrimaryMonitor();

--- a/core/backends/glfw/backend.cpp
+++ b/core/backends/glfw/backend.cpp
@@ -100,7 +100,7 @@ namespace backend {
             glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, OPENGL_VERSIONS_MAJOR[i]);
             glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, OPENGL_VERSIONS_MINOR[i]);
     #if GLFW_VERSION_MAJOR > 3 || (GLFW_VERSION_MAJOR == 3 && GLFW_VERSION_MINOR >= 4)
-                glfwWindowHintString(GLFW_WAYLAND_APP_ID, "sdrpp");
+            glfwWindowHintString(GLFW_WAYLAND_APP_ID, "sdrpp");
     #endif
             
             // Create window with graphics context


### PR DESCRIPTION
Added support for SDR++ to show the correct window icon under wayland sessions, instead of the default wayland one. As you can see in this screenshot: 
![image](https://github.com/user-attachments/assets/9986063f-aad0-4861-9eb5-5753b8ab8380)


