### PR TITLE
Update make_debian_package.sh

### DIFF
--- a/make_debian_package.sh
+++ b/make_debian_package.sh
@@ -22,7 +22,7 @@ cd $ORIG_DIR
 
 # Create package
 echo Create package
-dpkg-deb --build sdrpp_debian_amd64
+dpkg-deb --root-owner-group --build sdrpp_debian_amd64
 
 # Cleanup
 echo Cleanup


### PR DESCRIPTION
This solves the following warning

dpkg-deb: warning: root directory sdrpp_debian_amd64 has unusual owner or group xxxx:xxxx
dpkg-deb: hint: you might need to pass --root-owner-group, see <https://wiki.debian.org/Teams/Dpkg/RootlessBuilds> for further details

# Important

Only bandplan, colormaps and themes are accepted. Code pull requests are **NOT welcome**. 
Open an issue requesting a feature or discussing a possible bugfix instead.