### PR TITLE
Fix Linux PipeWire audio underruns 

### DIFF
--- a/sink_modules/audio_sink/src/main.cpp
+++ b/sink_modules/audio_sink/src/main.cpp
@@ -251,7 +251,11 @@ private:
     std::string sampleRatesTxt;
     unsigned int sampleRate = 48000;
 
+#ifdef __linux__
+    RtAudio audio{RtAudio::Api::LINUX_PULSE};  // PipeWire's default ALSA emulation causes underruns, so use PulseAudio emulation
+#else
     RtAudio audio;
+#endif
 };
 
 class AudioSinkModule : public ModuleManager::Instance {


### PR DESCRIPTION
Debian Trixie uses RTAudio 6.0 and PipeWire for its audio plumbing. SDR++ experiences constant, brutal audio underruns on this system:

```
[WARN] AudioSinkModule Warning: RtApiAlsa::callbackEvent: audio write error, underrun. (1)
```

I tried increasing the PipeWire "quantum" for larger buffers, lowering audio samplerate, tried the `new_portaudio_sink`, tried increasing the hard-coded number of buffer frames in the audio sink...

It turns out this problem is likely due to RtAudio's ALSA API implementation, as documented in this SDRPlusPlus Discussion: https://github.com/AlexandreRouma/SDRPlusPlus/discussions/112

This small PR switches RtAudio from using its default ALSA API backend to its PulseAudio API backend. This fixed the audio underrun problem on my Debian Trixie system, and should be completely transparent for any Linux system using PipeWire with `pipewire-pulse` like Debian, or any system using PulseAudio itself. 